### PR TITLE
Elasticsearch support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,7 @@ k8s_redis_volume_size: "20Gi"
 
 k8s_elasticsearch_enabled: false
 k8s_elasticsearch_cluster_name: "app-elasticsearch-cluster"
-k8s_elasticsearch_version: "6.8.6"
+k8s_elasticsearch_version: "7.5.2"
 k8s_elasticsearch_volume_size: "20Gi"
 
 k8s_environment_variables: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,7 @@ k8s_redis_version: "5.0.6"
 k8s_redis_volume_size: "20Gi"
 
 k8s_elasticsearch_enabled: false
-k8s_elasticsearch_version: "6.5.0"
+k8s_elasticsearch_version: "6.8.6"
 k8s_elasticsearch_volume_size: "20Gi"
 
 k8s_environment_variables: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,7 @@ k8s_redis_version: "5.0.6"
 k8s_redis_volume_size: "20Gi"
 
 k8s_elasticsearch_enabled: false
+k8s_elasticsearch_cluster_name: "app-elasticsearch-cluster"
 k8s_elasticsearch_version: "6.8.6"
 k8s_elasticsearch_volume_size: "20Gi"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,10 @@ k8s_redis_enabled: false
 k8s_redis_version: "5.0.6"
 k8s_redis_volume_size: "20Gi"
 
+k8s_elasticsearch_enabled: false
+k8s_elasticsearch_version: "6.5.0"
+k8s_elasticsearch_volume_size: "20Gi"
+
 k8s_environment_variables: {}
 
 k8s_ingress_certificate_issuer: letsencrypt-production
@@ -68,6 +72,8 @@ k8s_templates:
     state: present
   - name: redis.yaml.j2
     state: "{{ k8s_redis_enabled | ternary('present', 'absent') }}"
+  - name: elasticsearch.yaml.j2
+    state: "{{ k8s_elasticsearch_enabled | ternary('present', 'absent') }}"
   - name: memcached.yaml.j2
     state: "{{ k8s_memcached_enabled | ternary('present', 'absent') }}"
   - name: web.yaml.j2

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,1 +1,7 @@
 ---
+galaxy_info:
+  author: Caktus Consulting Group, LLC
+  description: Deploy Django applications with Kubernetes
+  company: Caktus Consulting Group, LLC
+  license: BSD
+dependencies: []

--- a/templates/elasticsearch.yaml.j2
+++ b/templates/elasticsearch.yaml.j2
@@ -9,7 +9,7 @@ data:
     cluster.initial_master_nodes: esnode-0,esnode-1
     network.host: "0.0.0.0"
     bootstrap.memory_lock: false
-    discovery.seed_hosts: elasticsearch-cluster
+    discovery.zen.ping.unicast.hosts: elasticsearch-cluster
     xpack.security.enabled: false
     xpack.monitoring.enabled: false
   ES_JAVA_OPTS: -Xms512m -Xmx512m
@@ -63,7 +63,7 @@ spec:
         readinessProbe:
           httpGet:
             scheme: HTTP
-            path: /_cluster/health?local=true
+            path: /_cluster/health?local=true&wait_for_status=green
             port: 9200
           initialDelaySeconds: 5
         ports:

--- a/templates/elasticsearch.yaml.j2
+++ b/templates/elasticsearch.yaml.j2
@@ -107,6 +107,7 @@ spec:
         requests:
           storage: {{ k8s_elasticsearch_volume_size }}
 ---
+# Service definition for making API calls to elasticsearch from within the cluster
 apiVersion: v1
 kind: Service
 metadata:

--- a/templates/elasticsearch.yaml.j2
+++ b/templates/elasticsearch.yaml.j2
@@ -6,6 +6,7 @@ metadata:
 data:
   elasticsearch.yml: |
     cluster.name: "{{ k8s_elasticsearch_cluster_name }}"
+    cluster.initial_master_nodes: esnode-0,esnode-1
     network.host: "0.0.0.0"
     bootstrap.memory_lock: false
     discovery.zen.ping.unicast.hosts: elasticsearch-cluster

--- a/templates/elasticsearch.yaml.j2
+++ b/templates/elasticsearch.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   namespace: "{{ k8s_namespace }}"
 data:
   elasticsearch.yml: |
-    cluster.name: my-elastic-cluster
+    cluster.name: "{{ k8s_elasticsearch_cluster_name }}"
     network.host: "0.0.0.0"
     bootstrap.memory_lock: false
     discovery.zen.ping.unicast.hosts: elasticsearch-cluster

--- a/templates/elasticsearch.yaml.j2
+++ b/templates/elasticsearch.yaml.j2
@@ -1,3 +1,4 @@
+# Service definition for the different elasticsearch instances to find each other
 apiVersion: v1
 kind: Service
 metadata:

--- a/templates/elasticsearch.yaml.j2
+++ b/templates/elasticsearch.yaml.j2
@@ -9,8 +9,7 @@ data:
     cluster.initial_master_nodes: esnode-0,esnode-1
     network.host: "0.0.0.0"
     bootstrap.memory_lock: false
-    discovery.zen.ping.unicast.hosts: elasticsearch-cluster
-    discovery.zen.minimum_master_nodes: 1
+    discovery.seed_hosts: elasticsearch-cluster
     xpack.security.enabled: false
     xpack.monitoring.enabled: false
   ES_JAVA_OPTS: -Xms512m -Xmx512m

--- a/templates/elasticsearch.yaml.j2
+++ b/templates/elasticsearch.yaml.j2
@@ -1,0 +1,124 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch-cluster
+  namespace: "{{ k8s_namespace }}"
+spec:
+  clusterIP: None
+  selector:
+    app: es-cluster
+  ports:
+  - name: transport
+    port: 9300
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: es-config
+  namespace: "{{ k8s_namespace }}"
+data:
+  elasticsearch.yml: |
+    cluster.name: my-elastic-cluster
+    network.host: "0.0.0.0"
+    bootstrap.memory_lock: false
+    discovery.zen.ping.unicast.hosts: elasticsearch-cluster
+    discovery.zen.minimum_master_nodes: 1
+    xpack.security.enabled: false
+    xpack.monitoring.enabled: false
+  ES_JAVA_OPTS: -Xms512m -Xmx512m
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: esnode
+  namespace: "{{ k8s_namespace }}"
+spec:
+  serviceName: elasticsearch
+  replicas: 2
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: es-cluster
+  template:
+    metadata:
+      labels:
+        app: es-cluster
+    spec:
+      securityContext:
+        fsGroup: 1000
+      initContainers:
+      - name: init-sysctl
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        command: ["sysctl", "-w", "vm.max_map_count=262144"]
+      containers:
+      - name: elasticsearch
+        resources:
+            requests:
+                memory: 1Gi
+        securityContext:
+          privileged: true
+          runAsUser: 1000
+          capabilities:
+            add:
+            - IPC_LOCK
+            - SYS_RESOURCE
+        image: "docker.elastic.co/elasticsearch/elasticsearch:{{ k8s_elasticsearch_version }}"
+        env:
+        - name: ES_JAVA_OPTS
+          valueFrom:
+              configMapKeyRef:
+                  name: es-config
+                  key: ES_JAVA_OPTS
+        readinessProbe:
+          httpGet:
+            scheme: HTTP
+            path: /_cluster/health?local=true
+            port: 9200
+          initialDelaySeconds: 5
+        ports:
+        - containerPort: 9200
+          name: es-http
+        - containerPort: 9300
+          name: es-transport
+        volumeMounts:
+        - name: es-data
+          mountPath: /usr/share/elasticsearch/data
+        - name: elasticsearch-config
+          mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
+          subPath: elasticsearch.yml
+      volumes:
+        - name: elasticsearch-config
+          configMap:
+            name: es-config
+            items:
+              - key: elasticsearch.yml
+                path: elasticsearch.yml
+  volumeClaimTemplates:
+  - metadata:
+      name: es-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: {{ k8s_elasticsearch_volume_size }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "elasticsearch"
+  labels:
+    app: "elasticsearch"
+  namespace: "{{ k8s_namespace }}"
+spec:
+  ports:
+  - protocol: TCP
+    # Where other things in the cluster should try to connect to our application
+    port: 9200
+    # Where our application is listening:
+    targetPort: 9200
+  selector:
+    app: "es-cluster"

--- a/templates/elasticsearch.yaml.j2
+++ b/templates/elasticsearch.yaml.j2
@@ -1,17 +1,3 @@
-# Service definition for the different elasticsearch instances to find each other
-apiVersion: v1
-kind: Service
-metadata:
-  name: elasticsearch-cluster
-  namespace: "{{ k8s_namespace }}"
-spec:
-  clusterIP: None
-  selector:
-    app: es-cluster
-  ports:
-  - name: transport
-    port: 9300
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -106,6 +92,20 @@ spec:
       resources:
         requests:
           storage: {{ k8s_elasticsearch_volume_size }}
+---
+# Service definition for the different elasticsearch instances to find each other
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch-cluster
+  namespace: "{{ k8s_namespace }}"
+spec:
+  clusterIP: None
+  selector:
+    app: es-cluster
+  ports:
+  - name: transport
+    port: 9300
 ---
 # Service definition for making API calls to elasticsearch from within the cluster
 apiVersion: v1

--- a/templates/elasticsearch.yaml.j2
+++ b/templates/elasticsearch.yaml.j2
@@ -102,7 +102,7 @@ spec:
   - metadata:
       name: es-data
     spec:
-      accessModes: [ "ReadWriteOnce" ]
+      accessModes: ["ReadWriteOnce"]
       resources:
         requests:
           storage: {{ k8s_elasticsearch_volume_size }}


### PR DESCRIPTION
Adoped from [Deploying Elasticsearch Within Kubernetes](https://rancher.com/blog/2018/2018-11-22-deploying-elasticsearch/) with @tobiasmcnulty.