### PR TITLE
Add minimum_master_nodes parameter

### DIFF
--- a/templates/elasticsearch.yaml.j2
+++ b/templates/elasticsearch.yaml.j2
@@ -10,6 +10,7 @@ data:
     network.host: "0.0.0.0"
     bootstrap.memory_lock: false
     discovery.zen.ping.unicast.hosts: elasticsearch-cluster
+    discovery.zen.minimum_master_nodes: 1
     xpack.security.enabled: false
     xpack.monitoring.enabled: false
   ES_JAVA_OPTS: -Xms512m -Xmx512m


### PR DESCRIPTION
Even though this prints a deprecation message in the logs, it helped the ES nodes find each other.