### PR TITLE
Fix Elasticsearch discovery

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,6 +46,7 @@ k8s_elasticsearch_enabled: false
 k8s_elasticsearch_cluster_name: "app-elasticsearch-cluster"
 k8s_elasticsearch_version: "7.5.2"
 k8s_elasticsearch_volume_size: "20Gi"
+k8s_elasticsearch_replicas: 3
 
 k8s_environment_variables: {}
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,6 +47,9 @@ k8s_elasticsearch_cluster_name: "app-elasticsearch-cluster"
 k8s_elasticsearch_version: "7.5.2"
 k8s_elasticsearch_volume_size: "20Gi"
 k8s_elasticsearch_replicas: 3
+k8s_elasticsearch_resources:
+  requests:
+    memory: "1Gi"
 
 k8s_environment_variables: {}
 

--- a/templates/elasticsearch.yaml.j2
+++ b/templates/elasticsearch.yaml.j2
@@ -9,8 +9,7 @@ data:
     cluster.initial_master_nodes: esnode-0
     network.host: "0.0.0.0"
     bootstrap.memory_lock: false
-    discovery.zen.ping.unicast.hosts: elasticsearch-cluster
-    discovery.zen.minimum_master_nodes: 1
+    discovery.seed_hosts: elasticsearch-cluster
     xpack.security.enabled: false
     xpack.monitoring.enabled: false
   ES_JAVA_OPTS: -Xms512m -Xmx512m

--- a/templates/elasticsearch.yaml.j2
+++ b/templates/elasticsearch.yaml.j2
@@ -6,7 +6,7 @@ metadata:
 data:
   elasticsearch.yml: |
     cluster.name: "{{ k8s_elasticsearch_cluster_name }}"
-    cluster.initial_master_nodes: esnode-0,esnode-1
+    cluster.initial_master_nodes: esnode-0
     network.host: "0.0.0.0"
     bootstrap.memory_lock: false
     discovery.zen.ping.unicast.hosts: elasticsearch-cluster

--- a/templates/elasticsearch.yaml.j2
+++ b/templates/elasticsearch.yaml.j2
@@ -43,9 +43,7 @@ spec:
         command: ["sysctl", "-w", "vm.max_map_count=262144"]
       containers:
       - name: elasticsearch
-        resources:
-            requests:
-                memory: 1Gi
+        resources: {{ k8s_elasticsearch_resources | to_json }}
         securityContext:
           privileged: true
           runAsUser: 1000

--- a/templates/elasticsearch.yaml.j2
+++ b/templates/elasticsearch.yaml.j2
@@ -62,11 +62,33 @@ spec:
                   name: es-config
                   key: ES_JAVA_OPTS
         readinessProbe:
-          httpGet:
-            scheme: HTTP
-            path: /_cluster/health?local=true&wait_for_status=green
-            port: 9200
           initialDelaySeconds: 5
+          exec:
+            command:
+              - sh
+              - -c
+              - |
+                #!/usr/bin/env bash -e
+                # If the node is starting up wait for the cluster to be ready' )
+                # Once it has started only check that the node itself is responding
+                START_FILE=/tmp/.es_start_file
+                http () {
+                    local path="${1}"
+                    curl -XGET -s -k --fail http://127.0.0.1:9200${path}
+                }
+                if [ -f "${START_FILE}" ]; then
+                    echo 'Elasticsearch is already running, lets check the node is healthy and there are master nodes available'
+                    http "/_cluster/health?timeout=0s"
+                else
+                    echo 'Waiting for elasticsearch cluster to become ready" )'
+                    if http "/_cluster/health?wait_for_status=green&timeout=1s" ; then
+                        touch ${START_FILE}
+                        exit 0
+                    else
+                        echo 'Cluster is not yet ready" )'
+                        exit 1
+                    fi
+                fi
         ports:
         - containerPort: 9200
           name: es-http

--- a/templates/elasticsearch.yaml.j2
+++ b/templates/elasticsearch.yaml.j2
@@ -62,7 +62,7 @@ spec:
                   name: es-config
                   key: ES_JAVA_OPTS
         readinessProbe:
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           exec:
             command:
               - sh

--- a/templates/elasticsearch.yaml.j2
+++ b/templates/elasticsearch.yaml.j2
@@ -21,7 +21,7 @@ metadata:
   namespace: "{{ k8s_namespace }}"
 spec:
   serviceName: elasticsearch
-  replicas: 2
+  replicas: {{ k8s_elasticsearch_replicas }}
   updateStrategy:
     type: RollingUpdate
   selector:

--- a/templates/elasticsearch.yaml.j2
+++ b/templates/elasticsearch.yaml.j2
@@ -80,12 +80,12 @@ spec:
                     echo 'Elasticsearch is already running, lets check the node is healthy and there are master nodes available'
                     http "/_cluster/health?timeout=0s"
                 else
-                    echo 'Waiting for elasticsearch cluster to become ready" )'
+                    echo 'Waiting for elasticsearch cluster to become ready'
                     if http "/_cluster/health?wait_for_status=green&timeout=1s" ; then
                         touch ${START_FILE}
                         exit 0
                     else
-                        echo 'Cluster is not yet ready" )'
+                        echo 'Cluster is not yet ready'
                         exit 1
                     fi
                 fi


### PR DESCRIPTION
* Designate esnode-0 to be the master
* Add smarter ``readinessProbe``
* Add ``k8s_elasticsearch_replicas`` defaulting to ``3``
* Add ``k8s_elasticsearch_resources`` defaulting to ``1Gi`` memory requests 