### PR TITLE
Help users more to set configuration for later use in CI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,14 @@ Changes
 v0.0.2 on TBD
 ~~~~~~~~~~~~~~~~~~~~~~
 
-* TBD
+* Made some changes to simplify setting up a deploy account so this can be run from
+  continuous integration.
+
+  *If updating from v0.0.1*:
+
+  * ``k8s_auth_host`` is now a required variable - see the README.rst.
+  * After setting that, please run first locally with kubectl set up
+    to access the cluster, and follow any instructions that are output.
 
 
 v0.0.1 on Mar 26, 2020

--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,8 @@ The ``k8s_auth_host`` variable is absolutely required to be set. This is the API
 endpoint URL of the cluster to use. Here are some examples so you can see what
 it might look like:
 
+AKS: ``https://ratom-staging-dns-ba5d6fd2.hcp.eastus.azmk8s.io:443``
+
 AWS: ``https://74406E3AD450E7845D0EF653E7C6F020.gr7.us-west-2.eks.amazonaws.com``
 
 Digital Ocean: ``https://fc22cd06-0dc4-4e19-a1cd-e0064d2d151e.k8s.ondigitalocean.com``

--- a/README.rst
+++ b/README.rst
@@ -63,31 +63,57 @@ Installation
             ansible_connection: local
           hosts:
             gcp-staging:
-              k8s_kube_context: <name of context from ~/.kube/config>
+              k8s_auth_host: <https://....Cluster API endpoint URL.....>
               k8s_domain_names:
               - www.example.com
 
 See ``defaults/main.yml`` for all the variables that can be overridden.
 
+The ``k8s_auth_host`` variable is absolutely required to be set. This is the API
+endpoint URL of the cluster to use. Here are some examples so you can see what
+it might look like:
+
+AWS: ``https://74406E3AD450E7845D0EF653E7C6F020.gr7.us-west-2.eks.amazonaws.com``
+
+Digital Ocean: ``https://fc22cd06-0dc4-4e19-a1cd-e0064d2d151e.k8s.ondigitalocean.com``
+
+GKE: ``https://104.196.6.244``
+
+Minikube: ``https://192.168.99.100:8443``
+
+If you're sure you have ``kubectl`` set up to talk to your cluster, then you can run this to
+print your ``k8s_auth_host`` value::
+
+    kubectl config view --minify=true -o jsonpath='{.clusters[0].cluster.server}' --raw
+
+Alternatively, if you used aws-web-stacks to create an EKS cluster, then the ``ClusterEndpoint``
+output in CloudFormation is the value to use.
+
 Usage
 -----
 
 This should be run first interactively by a user who is already set up to access the
-cluster using kubectl. E.g., they can run `kubectl cluster-info` and see the
+cluster using kubectl. E.g., they can run ``kubectl cluster-info`` and see the
 cluster info. How to achieve that will differ by Kubernetes hosting environment.
+
+(If when you try to run this role the first time, you get a bunch of SSL errors,
+check that ``k8s_auth_host`` and your current kubectl context are both pointing
+to the same cluster.)
 
 When run the first time, this will figure out some information using the
 user's kubectl access that the user will need to save in Ansible variables
 for later use by the CI test service.
 
 This role will also create a "deploy account" in Kubernetes which has the
-necessary permissions to deploy. It will print out a long random
-string which is the secret that can be used later to do Kubernetes activities
-using that deploy account (e.g. during CI tests and deploys).
+necessary permissions to deploy.
 
 Follow the instructions that are printed during that first run (putting some
 information into variables and files). Then run again, and this time it should
 complete successfully having created the various K8S objects.
+
+After that, the role should work without having to have kubectl access to the
+cluster. The user or service running it just needs access to the Ansible vault
+password, so ansible can decrypt the ``k8s_auth_api_key`` value.
 
 Configuration
 -------------

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,8 @@ caktus.django-k8s
 
 An Ansible role with sane defaults to deploy a Django app to Kubernetes.
 
+It also tries to arrange to be able to update the deploy from an automated
+CI service without requiring manual intervention for authentication.
 
 License
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -67,6 +69,25 @@ Installation
 
 See ``defaults/main.yml`` for all the variables that can be overridden.
 
+Usage
+-----
+
+This should be run first interactively by a user who is already set up to access the
+cluster using kubectl. E.g., they can run `kubectl cluster-info` and see the
+cluster info. How to achieve that will differ by Kubernetes hosting environment.
+
+When run the first time, this will figure out some information using the
+user's kubectl access that the user will need to save in Ansible variables
+for later use by the CI test service.
+
+This role will also create a "deploy account" in Kubernetes which has the
+necessary permissions to deploy. It will print out a long random
+string which is the secret that can be used later to do Kubernetes activities
+using that deploy account (e.g. during CI tests and deploys).
+
+Follow the instructions that are printed during that first run (putting some
+information into variables and files). Then run again, and this time it should
+complete successfully having created the various K8S objects.
 
 Configuration
 -------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,9 +3,6 @@
 # ansible-role-django-k8s performs a two-step deploy process.
 # First, it uses your (admin) credentials to create a namespace and service account;
 # those admin credentials should be defined with a combination of these variables:
-# (i.e., in your local ~/.kube/config):
-k8s_kube_config: "~/.kube/config"
-k8s_kube_context: ""
 
 # Next, after the service account is created, it obtains the authentication token
 # from the server and uses that to create the remaining resources in the namespace.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,10 +9,8 @@
     k8s_auth_api_key: "{{ ansible_env.K8S_AUTH_API_KEY }}"
   when: ansible_env.K8S_AUTH_API_KEY is defined
 
-- name: Create/update namespace
+- name: Create/update namespace (needed for deploy account)
   k8s:
-    context: "{{ k8s_kube_context }}"
-    kubeconfig: "{{ k8s_kube_config }}"
     definition: "{{ lookup('template', 'namespace.yaml.j2') }}"
     state: present
     # Ensure we see any failures in CI
@@ -20,42 +18,69 @@
     validate:
       fail_on_error: yes
       strict: yes
-  when: not k8s_auth_api_key
 
-- name: Create/update deploy account
-  k8s:
-    context: "{{ k8s_kube_context }}"
-    kubeconfig: "{{ k8s_kube_config }}"
-    definition: "{{ lookup('template', 'deploy_account.yaml.j2') }}"
-    state: present
-    # Ensure we see any failures in CI
-    wait: yes
-    validate:
-      fail_on_error: yes
-      strict: yes
-  register: deploy_account
-  when: not k8s_auth_api_key
+# Does the user need to set k8s_auth_host?
+- when: not k8s_auth_host
+  block:
+    - command: kubectl config view --minify=true -o jsonpath='{.clusters[0].cluster.server}' --raw
+      register: data_command
+    - debug:
+        msg: |
+          # Add this to your variables:
+          k8s_auth_host: "{{ data_command.stdout }}"
+          # Then run again
 
-- name: Get deploy account token
-  k8s_info:
-    kind: Secret
-    namespace: "{{ k8s_namespace }}"
-    name: "{{ deploy_account.result.results.0.result.secrets.0.name }}"
-  register: deploy_account_token
-  when: not k8s_auth_api_key
+# Does the user need to set k8s_auth_ssl_ca_cert?
+- when: not k8s_auth_ssl_ca_cert
+  block:
+    - command: kubectl config view --minify=true -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' --raw
+      register: data_command
+    - debug:
+         msg: |
+           1) Create a file (maybe k8s_auth_ssl_ca_cert.txt) and set contents to
+           {{ data_command.stdout | b64decode }}
+           with all indentation removed. (This does not need to be secret.)
+           2) Set k8s_auth_ssl_ca_cert to the path to the file.
+           3) Run again after doing that
 
-- name: Set k8s_auth_api_key
-  set_fact:
-    k8s_auth_api_key: "{{ deploy_account_token.resources.0.data.token | b64decode }}"
-  when: not k8s_auth_api_key
+# Does the user need to set k8s_auth_api_key?
+- when: not k8s_auth_api_key
+  block:
+  - name: Create/update deploy account
+    k8s:
+      definition: "{{ lookup('template', 'deploy_account.yaml.j2') }}"
+      state: present
+      # Ensure we see any failures in CI
+      wait: yes
+      validate:
+        fail_on_error: yes
+        strict: yes
+    register: deploy_account
 
-- name: Output k8s_auth_api_key
-  debug: var=k8s_auth_api_key
-  when: echo_token is defined and echo_token
+  - set_fact:
+      deploy_account_name: "{{ deploy_account.result.results.0.result.secrets.0.name }}"
 
-- name: Fail if k8s_auth_host or k8s_auth_ssl_ca_cert is unset
-  fail: msg="k8s_auth_host or k8s_auth_ssl_ca_cert not set!"
-  when: not (k8s_auth_host and k8s_auth_ssl_ca_cert)
+  - name: Get deploy account secret (contains secret token=k8s_auth_api_key)
+    k8s_info:
+      kind: Secret
+      namespace: "{{ k8s_namespace }}"
+      name: "{{ deploy_account_name }}"
+    register: deploy_account_secret
+
+  - debug:
+      msg: |
+        # Set a variable as follows:
+        k8s_auth_api_key: "{{ deploy_account_secret.resources.0.data.token | b64decode }}"
+        # THIS MUST BE KEPT SECRET, so encrypt the entry or the variables file.
+        # Then run again.
+
+# Did we have to show the user some settings that needed to be made?
+- when: not k8s_auth_host or not k8s_auth_ssl_ca_cert or not k8s_auth_api_key
+  fail:
+    msg: "Please follow the instructions above, then run again"
+
+# FROM here on, we have the information we need to use the deploy account instead of
+# the user's own credentials to deploy etc in our Kubernetes cluster.
 
 - name: Create/update templates in Kubernetes
   k8s:
@@ -70,4 +95,3 @@
       fail_on_error: yes
       strict: yes
   with_items: "{{ k8s_templates }}"
-  when: k8s_auth_host and k8s_auth_ssl_ca_cert

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,6 +20,24 @@
 #
 # when communicating with the cluster. This makes sure we're talking to the right one.
 
+- block:
+  - name: Query nodes to check cluster connection using {{ k8s_auth_host }} and the user's kubectl context
+    k8s_info:
+      kind: Node
+      host: "{{ k8s_auth_host }}"
+    register: node_query_result
+    ignore_errors: True
+
+  - name: Fail play if above Node query was unsuccessful
+    fail:
+      msg: |
+        *************************************************************************************************************************************
+        Unable to access the cluster. Are you using the correct kubectl context? (Especially if the previous message was about an SSLError.)"
+        *************************************************************************************************************************************
+    when:
+      - "'rc' in node_query_result"
+      - node_query_result.rc == 1
+
 # Does the user need to set k8s_auth_ssl_ca_cert?
 - when: not k8s_auth_ssl_ca_cert
   block:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,26 +9,16 @@
     k8s_auth_api_key: "{{ ansible_env.K8S_AUTH_API_KEY }}"
   when: ansible_env.K8S_AUTH_API_KEY is defined
 
-- name: Create/update namespace (needed for deploy account)
-  k8s:
-    definition: "{{ lookup('template', 'namespace.yaml.j2') }}"
-    state: present
-    # Ensure we see any failures in CI
-    wait: yes
-    validate:
-      fail_on_error: yes
-      strict: yes
-
 # Does the user need to set k8s_auth_host?
 - when: not k8s_auth_host
-  block:
-    - command: kubectl config view --minify=true -o jsonpath='{.clusters[0].cluster.server}' --raw
-      register: data_command
-    - debug:
-        msg: |
-          # Add this to your variables:
-          k8s_auth_host: "{{ data_command.stdout }}"
-          # Then run again
+  fail:
+    msg: "k8s_auth_host must be set. Please see the role documentation."
+
+# FROM here on, always specify
+#
+#          host: "{{ k8s_auth_host }}"
+#
+# when communicating with the cluster. This makes sure we're talking to the right one.
 
 # Does the user need to set k8s_auth_ssl_ca_cert?
 - when: not k8s_auth_ssl_ca_cert
@@ -46,10 +36,22 @@
 # Does the user need to set k8s_auth_api_key?
 - when: not k8s_auth_api_key
   block:
+  - name: Create/update namespace (needed for deploy account)
+    k8s:
+      definition: "{{ lookup('template', 'namespace.yaml.j2') }}"
+      state: present
+      host: "{{ k8s_auth_host }}"
+      # Ensure we see any failures in CI
+      wait: yes
+      validate:
+        fail_on_error: yes
+        strict: yes
+
   - name: Create/update deploy account
     k8s:
       definition: "{{ lookup('template', 'deploy_account.yaml.j2') }}"
       state: present
+      host: "{{ k8s_auth_host }}"
       # Ensure we see any failures in CI
       wait: yes
       validate:
@@ -65,6 +67,7 @@
       kind: Secret
       namespace: "{{ k8s_namespace }}"
       name: "{{ deploy_account_name }}"
+      host: "{{ k8s_auth_host }}"
     register: deploy_account_secret
 
   - debug:
@@ -75,18 +78,20 @@
         # Then run again.
 
 # Did we have to show the user some settings that needed to be made?
-- when: not k8s_auth_host or not k8s_auth_ssl_ca_cert or not k8s_auth_api_key
+- when: not k8s_auth_ssl_ca_cert or not k8s_auth_api_key
   fail:
     msg: "Please follow the instructions above, then run again"
 
 # FROM here on, we have the information we need to use the deploy account instead of
-# the user's own credentials to deploy etc in our Kubernetes cluster.
+# the user's own credentials to deploy etc in our Kubernetes cluster.  api_key and
+# ca_cert provide authentication and authorization. host is to specify which cluster
+# to talk to.
 
 - name: Create/update templates in Kubernetes
   k8s:
     api_key: "{{ k8s_auth_api_key }}"
-    host: "{{ k8s_auth_host }}"
     ca_cert: "{{ k8s_auth_ssl_ca_cert }}"
+    host: "{{ k8s_auth_host }}"
     definition: "{{ lookup('template', item['name']) }}"
     state: "{{ item['state'] }}"
     # Ensure we see any failures in CI

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,23 +20,33 @@
 #
 # when communicating with the cluster. This makes sure we're talking to the right one.
 
-- block:
-  - name: Query nodes to check cluster connection using {{ k8s_auth_host }} and the user's kubectl context
-    k8s_info:
-      kind: Node
-      host: "{{ k8s_auth_host }}"
-    register: node_query_result
-    ignore_errors: True
+# CHECK that the right kubectl context is set. Note that this will fail to run at all if we're running
+# in CI without a kubectl context, and that's okay so long as we have enough other information
+# to run without it, which we'll check next.
+- name: See what host the current kubectl context is using
+  command: kubectl config view --minify=true -o jsonpath='{.clusters[0].cluster.server}' --raw
+  register: context_out
+  ignore_errors: true
+- set_fact:
+    host_from_kubectl: "{{ (context_out is succeeded) and context_out.stdout }}"
+    kubeconfig_valid: "{{ (context_out is succeeded) and (context_out.stdout == k8s_auth_host) }}"
 
-  - name: Fail play if above Node query was unsuccessful
-    fail:
-      msg: |
-        *************************************************************************************************************************************
-        Unable to access the cluster. Are you using the correct kubectl context? (Especially if the previous message was about an SSLError.)"
-        *************************************************************************************************************************************
-    when:
-      - "'rc' in node_query_result"
-      - node_query_result.rc == 1
+# If we don't have all the config we need to work without kubectl,
+# check that kubectl has the right context set because we'll need it.
+- when: not kubeconfig_valid and ((not k8s_auth_ssl_ca_cert) or (not k8s_auth_api_key))
+  fail:
+    msg: |
+       *************************************************************
+
+       The current kubectl context does not match the k8s_auth_host,
+       or is simply not working for some reason.
+       The Ansible variable k8s_auth_host is {{ k8s_auth_host }}
+       The host from the kubectl context is {{ host_from_kubectl }}
+       Please use 'kubectl config use-context' to change to the
+       context for the cluster you're deploying to.  You can list
+       your contexts with 'kubectl config get-contexts'
+
+       *************************************************************
 
 # Does the user need to set k8s_auth_ssl_ca_cert?
 - when: not k8s_auth_ssl_ca_cert
@@ -104,6 +114,21 @@
 # the user's own credentials to deploy etc in our Kubernetes cluster.  api_key and
 # ca_cert provide authentication and authorization. host is to specify which cluster
 # to talk to.
+
+# The definition of the deploy account may have changed, so make sure it is current.
+# Just note that the deploy account doesn't have permission to change itself, so we
+# can only do this when we've been run with valid kubeconfig access.
+- when: kubeconfig_valid
+  name: Update deploy account
+  k8s:
+    definition: "{{ lookup('template', 'deploy_account.yaml.j2') }}"
+    state: present
+    host: "{{ k8s_auth_host }}"
+    # Ensure we see any failures in CI
+    wait: yes
+    validate:
+      fail_on_error: yes
+      strict: yes
 
 # Run migrations if wanted
 - when: k8s_migrations_enabled


### PR DESCRIPTION
As long as a user has kubectl set up to access their kubernetes cluster, they can start using this role and it'll set up a deploy account (if there's not one already) and print out instructions to configure ansible to use it.