### PR TITLE
Wait for migrations to complete before continuing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ Changes
 v0.0.2 on TBD
 ~~~~~~~~~~~~~~~~~~~~~~
 
-* Wait until Job-created migration pod returns ``Completed`` status before contining deploy
+* Wait until Job-created migration pod returns ``Completed`` status before continuing deploy
 
 
 v0.0.1 on Mar 26, 2020

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ Changes
 v0.0.2 on TBD
 ~~~~~~~~~~~~~~~~~~~~~~
 
-* TBD
+* Wait until Job-created migration pod returns ``Completed`` status before contining deploy
 
 
 v0.0.1 on Mar 26, 2020

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -82,6 +82,9 @@
       definition: "{{ lookup('template', 'batchjob.yaml.j2') }}"
       state: present
       wait: yes
+      wait_condition:
+        type: Complete
+        status: "True"
       validate:
         fail_on_error: yes
         strict: yes


### PR DESCRIPTION
Wait until Job-created migration pod returns ``Completed`` status before continuing deploy.