### PR TITLE
Pull celerybeat based on worker pull policy

### DIFF
--- a/templates/workers_beat.yaml.j2
+++ b/templates/workers_beat.yaml.j2
@@ -23,7 +23,7 @@ spec:
       containers:
       - name: "celery-beat"
         image: "{{ k8s_worker_container["image"] }}:{{ k8s_worker_container["tag"] }}"
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: "{{ k8s_worker_container["image_pull_policy"] }}"
         args: ["celery", "--app={{ k8s_worker_container["celery_app"] }}", "beat", "--workdir=/code", "--loglevel=info", "--pidfile=/data/beat.pid", "--schedule=/data/schedulefile.db"]
         env:
         - name: GET_HOSTS_FROM


### PR DESCRIPTION
I'm not sure if this is the correct solution, but on pressweb, celerybeat was stuck on a very old image, despite the fact that we had made updates to the image. Changing it to this and then deleting the pod brought it up to date.