### PR TITLE
Allow celery-beat to use the data volume

### DIFF
--- a/templates/workers_beat.yaml.j2
+++ b/templates/workers_beat.yaml.j2
@@ -20,6 +20,8 @@ spec:
 {% else %}
       imagePullSecrets: []
 {% endif %}
+      securityContext:
+        fsGroup: 2000
       containers:
       - name: "celery-beat"
         image: "{{ k8s_worker_container["image"] }}:{{ k8s_worker_container["tag"] }}"


### PR DESCRIPTION
When I started up celery-beat on a project that didn't run as root, I got this error: `celery.platforms.LockFailed: [Errno 13] Permission denied: '/data/beat.pid'`

When I looked at the filesystem, the data volume had been mounted as root (and it happens after the permissions change that we did in the dockerfile).

I believe this is the recommended approach: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod

`fsGroup` specifies a group ID that will be added to any processes started in the container, and any volumes mounted will be mounted with that group. (The number 2000 isn't magic. We can choose any number that doesn't clash with the few groups that are on these containers)