### PR TITLE
Get celery working

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -101,26 +101,18 @@ k8s_worker_resources: "{{ k8s_container_resources }}"
 k8s_worker_celery_app: ""
 k8s_worker_command:
   - celery
-  - --app
-  - "{{ k8s_worker_celery_app }}"
+  - --app={{ k8s_worker_celery_app }}
   - worker
-  - --workdir
-  - "/code"
-  - --loglevel
-  - "info"
+  - --workdir=/code
+  - --loglevel=info
 k8s_worker_beat_command:
-  - celery 
-  - --app
-  - "{{ k8s_worker_celery_app }}" 
-  - beat 
-  - --workdir
-  - "/code" 
-  - --loglevel
-  - "info" 
-  - --pidfile
-  - "/data/beat.pid" 
-  - --schedule
-  - "/data/schedulefile.db"
+  - celery
+  - --app={{ k8s_worker_celery_app }}
+  - beat
+  - --workdir=/code
+  - --loglevel=info
+  - --pidfile=/data/beat.pid
+  - --schedule=/data/schedulefile.db
 k8s_worker_container:
   image: "{{ k8s_worker_image }}"
   image_pull_policy: "{{ k8s_worker_image_pull_policy }}"

--- a/templates/workers.yaml.j2
+++ b/templates/workers.yaml.j2
@@ -39,7 +39,8 @@ spec:
       - name: "celery-worker"
         image: "{{ k8s_worker_container["image"] }}:{{ k8s_worker_container["tag"] }}"
         imagePullPolicy: "{{ k8s_worker_container["image_pull_policy"] }}"
-        command: {{ k8s_worker_container["worker_command"] }}
+        # command: do not override `command:` as we want to run the docker-entrypoint.sh before starting args
+        args: {{ k8s_worker_container["worker_command"] }}
         env:
         - name: GET_HOSTS_FROM
           value: dns

--- a/templates/workers_beat.yaml.j2
+++ b/templates/workers_beat.yaml.j2
@@ -26,7 +26,8 @@ spec:
       - name: "celery-beat"
         image: "{{ k8s_worker_container["image"] }}:{{ k8s_worker_container["tag"] }}"
         imagePullPolicy: "{{ k8s_worker_container["image_pull_policy"] }}"
-        command: {{ k8s_worker_container["beat_command"] }}
+        # command: do not override `command:` as we want to run the docker-entrypoint.sh before starting args
+        args: {{ k8s_worker_container["beat_command"] }}
         env:
         - name: GET_HOSTS_FROM
           value: dns


### PR DESCRIPTION
When deploying to PW, celery complained with a 'usage' error:
```
+ exec celery --app pressweb worker --workdir /code --loglevel info
 usage: celery <command> [options] 
```
Using a format of `--flag=value` did not raise the error:
```
+ exec celery --app=pressweb worker --workdir=/code --loglevel=info
 -------------- celery@celery-worker-547776b6cb-k496z v4.4.5 (cliffs)
```
... so I have switched the format here to use the second format.

In addition, I noticed that using the `command` k8s key [overrides the dockerfile ENTRYPOINT variable](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#notes), which we don't necessarily want to do, so I've left a comment about that.
