### PR TITLE
Amazon S3: buckets with IAM role for K8s service accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode
+.python-version

--- a/README.rst
+++ b/README.rst
@@ -170,7 +170,7 @@ A separate playbook can be used to invoke this functionality:
 .. code-block:: yaml
 
   ---
-  # file: s3.yaml
+  # file: deploy-s3.yaml
 
   - hosts: k8s
     vars:
@@ -181,3 +181,5 @@ A separate playbook can be used to invoke this functionality:
         import_role:
           name: caktus.django-k8s
           tasks_from: aws_s3
+
+Run with: ``ansible-playbook deploy-s3.yml``.

--- a/README.rst
+++ b/README.rst
@@ -144,7 +144,7 @@ Celery
 Amazon S3: IAM role for service accounts
 ````````````````````````````````````````
 
-Django applications running on AWS typically use Amazon S3 for static and media
+Web applications running on AWS typically use Amazon S3 for static and media
 resources. ``caktus.django-k8s`` optionally supports enabling a Kubernetes
 service account and associated IAM role that defines the access to public and
 private S3 buckets. This provides similar functionality of

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -144,7 +144,7 @@ k8s_collectstatic_command:
   - -v
   - "2"
 
-k8s_s3_cluster_name: ""
+k8s_s3_cluster_name: ""  # name of EKS cluster in AWS
 k8s_s3_region: "us-east-1"
 k8s_s3_namespace: "{{ k8s_namespace }}"
 k8s_s3_iam_role: "S3ServiceAccountRole-{{ k8s_s3_namespace }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -144,6 +144,14 @@ k8s_collectstatic_command:
   - -v
   - "2"
 
+k8s_s3_cluster_name: ""
+k8s_s3_region: "us-east-1"
+k8s_s3_namespace: "{{ k8s_namespace }}"
+k8s_s3_iam_role: "S3ServiceAccountRole-{{ k8s_s3_namespace }}"
+k8s_s3_serviceaccount: "default"
+k8s_s3_public_bucket: "{{ k8s_s3_namespace }}-assets"
+k8s_s3_private_bucket: "{{ k8s_s3_namespace }}-private-assets"
+
 k8s_templates:
   - name: registry_secret.yaml.j2
     state: "{{ k8s_dockerconfigjson | ternary('present', 'absent') }}"

--- a/tasks/aws_s3.yml
+++ b/tasks/aws_s3.yml
@@ -1,0 +1,104 @@
+---
+
+#
+# Public S3 assets bucket
+#
+
+- name: "create public bucket {{ k8s_s3_public_bucket }}"
+  s3_bucket:
+    name: "{{ k8s_s3_public_bucket }}"
+    state: present
+    versioning: yes
+    region: "{{ k8s_s3_region }}"
+
+#
+# Private S3 assets bucket
+#
+
+- name: "create private bucket {{ k8s_s3_private_bucket }}"
+  s3_bucket:
+    name: "{{ k8s_s3_private_bucket }}"
+    state: present
+    versioning: yes
+    region: "{{ k8s_s3_region }}"
+    encryption: AES256
+
+# Not available via Ansible module as of 7/2020
+- name: "block all public access to {{ k8s_s3_private_bucket }}"
+  command:
+    argv:
+      - aws
+      - s3api
+      - put-public-access-block
+      - --bucket
+      - "{{ k8s_s3_private_bucket }}"
+      - --public-access-block-configuration
+      - BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=false
+
+#
+# IAM OIDC identity provider and issuer
+#
+
+# https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html
+- name: create an IAM OIDC identity provider for the cluster
+  command: "eksctl utils associate-iam-oidc-provider --cluster {{ k8s_s3_cluster_name }} --approve"
+  register: associate_response
+  changed_when: "'created' in associate_response.stdout"
+
+# Not available via Ansible module as of 7/2020
+- name: describe cluster to obtain OIDC issuer
+  command: "aws eks describe-cluster --region {{ k8s_s3_region }} --name {{ k8s_s3_cluster_name }} --output json"
+  changed_when: false
+  register: cluster_query
+
+- name: parse OIDC issuer from response
+  set_fact:
+    oidc_issuer: "{{ cluster_query.stdout | from_json | json_query('cluster.identity.oidc.issuer') | regex_replace('https://') }}"
+
+#
+# AWS Account ID
+#
+
+- name: get the current caller identity information
+  aws_caller_info:
+  register: caller_info
+
+- name: parse AWS account ID
+  set_fact:
+    aws_account_id: "{{ caller_info.account }}"
+
+#
+# IAM Role
+#
+
+# https://docs.aws.amazon.com/eks/latest/userguide/create-service-account-iam-policy-and-role.html
+- name: Create IAM role for K8s service account
+  iam_role:
+    name: "{{ k8s_s3_iam_role }}"
+    assume_role_policy_document: "{{ lookup('template', 's3/TrustPolicy.json.j2') }}"
+    description: IAM role for K8s service account
+
+- name: Attach inline policy to user
+  iam_policy:
+    iam_type: role
+    iam_name: "{{ k8s_s3_iam_role }}"
+    policy_name: "EKSBucketPolicy"
+    state: present
+    policy_json: "{{ lookup( 'template', 's3/AssetManagementPolicy.json.j2') }}"
+
+#
+# Service Account
+#
+
+# https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html
+- name: "Associate IAM role with the service account in your cluster"
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: "{{ k8s_s3_serviceaccount }}"
+        namespace: "{{ k8s_s3_namespace }}"
+        annotations:
+          eks.amazonaws.com/role-arn: "arn:aws:iam::{{ aws_account_id }}:role/{{ k8s_s3_iam_role }}"

--- a/tasks/aws_s3.yml
+++ b/tasks/aws_s3.yml
@@ -40,6 +40,9 @@
 #
 
 # https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html
+# Possibly replace in future with (to remove eksctl requirement):
+#    1. https://docs.aws.amazon.com/cli/latest/reference/iam/create-open-id-connect-provider.html
+#    2. https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
 - name: create an IAM OIDC identity provider for the cluster
   command: "eksctl utils associate-iam-oidc-provider --cluster {{ k8s_s3_cluster_name }} --approve"
   register: associate_response

--- a/tasks/aws_s3.yml
+++ b/tasks/aws_s3.yml
@@ -33,7 +33,7 @@
       - --bucket
       - "{{ k8s_s3_private_bucket }}"
       - --public-access-block-configuration
-      - BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=false
+      - BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
 
 #
 # IAM OIDC identity provider and issuer

--- a/templates/s3/AssetManagementPolicy.json.j2
+++ b/templates/s3/AssetManagementPolicy.json.j2
@@ -1,0 +1,25 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::{{ k8s_s3_public_bucket }}",
+        "arn:aws:s3:::{{ k8s_s3_private_bucket }}",
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": [
+        "arn:aws:s3:::{{ k8s_s3_public_bucket }}/*",
+        "arn:aws:s3:::{{ k8s_s3_private_bucket }}/*"
+      ]
+    }
+  ]
+}

--- a/templates/s3/AssetManagementPolicy.json.j2
+++ b/templates/s3/AssetManagementPolicy.json.j2
@@ -8,7 +8,7 @@
       ],
       "Resource": [
         "arn:aws:s3:::{{ k8s_s3_public_bucket }}",
-        "arn:aws:s3:::{{ k8s_s3_private_bucket }}",
+        "arn:aws:s3:::{{ k8s_s3_private_bucket }}"
       ]
     },
     {

--- a/templates/s3/TrustPolicy.json.j2
+++ b/templates/s3/TrustPolicy.json.j2
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::{{ aws_account_id }}:oidc-provider/{{ oidc_issuer }}"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "{{ oidc_issuer }}:sub": "system:serviceaccount:{{ k8s_s3_namespace }}:{{ k8s_s3_serviceaccount }}"
+        }
+      }
+    }
+  ]
+}

--- a/templates/web.yaml.j2
+++ b/templates/web.yaml.j2
@@ -49,7 +49,8 @@ spec:
         ports:
         - containerPort: {{ container["port"] }}
         resources: {{ container["resources"] | to_json }}
-      securityContext: {}
+      securityContext:
+        fsGroup: 2000
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Add optional support for enabling a Kubernetes service account and associated IAM role that defines the access to public and private S3 buckets for each environment. This provides similar functionality of [EC2 instance profiles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html) within Kubernetes namespaces.

At a high level, the process is:

1. Create environment-specific public and private S3 buckets
2. [Enable IAM roles for cluster service accounts](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html)
    * Requirement: [eksctl](https://eksctl.io/introduction/#installation) must be installed
3. [Create an IAM role with a trust relatinoship and S3 policy for a service account](https://docs.aws.amazon.com/eks/latest/userguide/create-service-account-iam-policy-and-role.html)
4. [Annotate the service account with the ARN of the IAM role](https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html>)
5. Pods have read/write access to buckets w/o access keys

The ``securityContext`` also had to be updated so that non-root users could access the token on the filesystem in the container per this [solution](https://github.com/kubernetes-sigs/external-dns/pull/1185#issuecomment-530439786).

I debated whether or not this should exist here or within [ansible-role-k8s-web-cluster](https://github.com/caktus/ansible-role-k8s-web-cluster). I ended up settling on here due to the re-use of environment-specific variables. However, it certainly touches on both projects and am open to suggestions.