### PR TITLE
Support root and www redirect

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,12 @@ caktus.django-k8s
 Changes
 -------
 
+v0.0.8 on Sep 21, 2020
+~~~~~~~~~~~~~~~~~~~~~~
+
+* Suport redirect from www.domain.com to domain.com or vice versa.
+
+
 v0.0.7 on Jul 28, 2020
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,7 @@ k8s_rollout_after_deploy: False
 
 k8s_domain_names:
   - www.example.com
+k8s_redirect_domain_names: []
 
 k8s_namespace: "echoserver"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,7 +38,14 @@ k8s_rollout_after_deploy: False
 
 k8s_domain_names:
   - www.example.com
-k8s_redirect_domain_names: []
+# In some scenarios is required to redirect from www.domain.com to
+# domain.com or vice versa (feature of NGINX Ingress Controller).
+#   Note: If enabled, the redirected domain must be manually added
+#   to the k8s_ingress_tls_domains_extra variable to create a
+#   corresponding TLS certificate, e.g,:
+#     k8s_ingress_tls_domains_extra: [example.com]
+#   https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#redirect-fromto-www
+k8s_domain_from_to_www_redirect: false
 
 k8s_namespace: "echoserver"
 
@@ -61,6 +68,10 @@ k8s_elasticsearch_resources:
 k8s_environment_variables: {}
 
 k8s_ingress_certificate_issuer: letsencrypt-production
+# user-provided additional domain names to be associated with
+# TLS certificate as Subject Alternative Name(s)
+k8s_ingress_tls_domains_extra: []
+k8s_ingress_tls_domains: "{{ k8s_domain_names + k8s_ingress_tls_domains_extra }}"
 
 k8s_container_name: web
 k8s_container_image: k8s.gcr.io/echoserver

--- a/templates/web.yaml.j2
+++ b/templates/web.yaml.j2
@@ -84,7 +84,7 @@ metadata:
 spec:
   tls:
   - hosts:
-{% for domain in k8s_domain_names %}
+{% for domain in k8s_domain_names + k8s_redirect_domain_names %}
     - "{{ domain }}"
 {% endfor %}
     secretName: "{{ k8s_namespace }}-tls"

--- a/templates/web.yaml.j2
+++ b/templates/web.yaml.j2
@@ -84,7 +84,7 @@ metadata:
 spec:
   tls:
   - hosts:
-{% for domain in k8s_domain_names + k8s_redirect_domain_names %}
+{% for domain in k8s_ingress_tls_domains %}
     - "{{ domain }}"
 {% endfor %}
     secretName: "{{ k8s_namespace }}-tls"
@@ -120,6 +120,11 @@ metadata:
     nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
 {% else %}{# Disable basic auth, in case it was enabled previously. #}
     nginx.ingress.kubernetes.io/auth-type: ""
+{% endif %}
+{% if k8s_domain_from_to_www_redirect %}
+    nginx.ingress.kubernetes.io/from-to-www-redirect: 'true'
+{% else %}
+    nginx.ingress.kubernetes.io/from-to-www-redirect: 'false'
 {% endif %}
 {% for key, value in container["ingress_annotations"].items() %}
     {{ key }}: "{{ value }}"


### PR DESCRIPTION
Support hosting on either a root or www domain with a redirect to the primary domain:

* Create TLS certificates for additional domains with ``k8s_ingress_tls_domains_extra``
* Add ``k8s_domain_from_to_www_redirect`` to toggle the [NGINX Ingress feature](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#redirect-fromto-www) for redirecting to either a root or www domain automatically. A ``server`` block like this is added under the hood:

    ```nginx
    ## start server caktus-website-prod-k8s.caktus-built.com
    server {
            server_name caktus-website-prod-k8s.caktus-built.com;

            listen 80  ;
            listen 443  ssl http2 ;

            ssl_certificate_by_lua_block {
                    certificate.call()
            }

            return 308 $scheme://www.caktus-website-prod-k8s.caktus-built.com$request_uri;

    }
    ## end server caktus-website-prod-k8s.caktus-built.com
    ```

    This seemed like the most straightforward yet extensible method. It would be possible to inspect ``k8s_domain_names[0]`` and add the opposite domain to ``k8s_ingress_tls_domains_extra``, but (1) it gets more complicated to support additional redirect domains and (2) I couldn't think of an easy way to do it with yaml + jinja.

Example configuration:

```yaml
k8s_domain_names:
- www.caktus-website-prod-k8s.caktus-built.com
# Enable root domain redirect to www
k8s_domain_from_to_www_redirect: true
# Also include the root domain in the TLS certificate, even though
# we'll just issue a redirect to the www domain above
k8s_ingress_tls_domains_extra:
- caktus-website-prod-k8s.caktus-built.com
```