### PR TITLE
Add k8s_domain_redirects

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,6 +46,7 @@ k8s_domain_names:
 #     k8s_ingress_tls_domains_extra: [example.com]
 #   https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#redirect-fromto-www
 k8s_domain_from_to_www_redirect: false
+k8s_domain_redirects: []
 
 k8s_namespace: "echoserver"
 
@@ -71,7 +72,7 @@ k8s_ingress_certificate_issuer: letsencrypt-production
 # user-provided additional domain names to be associated with
 # TLS certificate as Subject Alternative Name(s)
 k8s_ingress_tls_domains_extra: []
-k8s_ingress_tls_domains: "{{ k8s_domain_names + k8s_ingress_tls_domains_extra }}"
+k8s_ingress_tls_domains: "{{ k8s_domain_names + k8s_domain_redirects + k8s_ingress_tls_domains_extra }}"
 
 k8s_container_name: web
 k8s_container_image: k8s.gcr.io/echoserver

--- a/templates/web.yaml.j2
+++ b/templates/web.yaml.j2
@@ -89,7 +89,7 @@ spec:
 {% endfor %}
     secretName: "{{ k8s_namespace }}-tls"
   rules:
-{% for domain in k8s_domain_names %}
+{% for domain in k8s_domain_names + k8s_domain_redirects %}
   - host: "{{ domain }}"
 {% endfor %}
 {% for container in k8s_web_containers %}
@@ -142,4 +142,24 @@ spec:
           servicePort: {{ container["port"] }}
 {% endfor %}
 {% endfor %}
+{% if k8s_domain_redirects %}
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: "ingress-redirect"
+  namespace: "{{ k8s_namespace }}"
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/backend-protocol: "{{ container["protocol"] }}"
+    nginx.ingress.kubernetes.io/server-snippet: |
+      if ($host ~* ^({{ k8s_domain_redirects | default([]) | join('|') }})$) {
+          return 301 $scheme://{{ k8s_domain_names[0] }}$request_uri;
+      }
+spec:
+  rules:
+{% for domain in k8s_domain_redirects %}
+  - host: "{{ domain }}"
+{% endfor %}
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
Extends #30 to support additional redirect domains:

* Create a redirect-specific ``Ingress``, ``ingress-redirect``, which only redirects domains to the first k8s domain ``k8s_domain_names[0]``.

This works, but the generated nginx server block still contains all the proxy pass related configuration, which doesn't seem ideal.