### PR TITLE
[ISSUE-28] Move template creation before migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 .vscode
 .python-version

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -130,6 +130,20 @@
       fail_on_error: yes
       strict: yes
 
+- name: Create/update templates in Kubernetes
+  k8s:
+    api_key: "{{ k8s_auth_api_key }}"
+    ca_cert: "{{ k8s_auth_ssl_ca_cert }}"
+    host: "{{ k8s_auth_host }}"
+    definition: "{{ lookup('template', item['name']) }}"
+    state: "{{ item['state'] }}"
+    # Ensure we see any failures in CI
+    wait: yes
+    validate:
+      fail_on_error: yes
+      strict: yes
+  with_items: "{{ k8s_templates }}"
+
 # Run migrations if wanted
 - when: k8s_migrations_enabled
   vars:
@@ -193,20 +207,6 @@
       validate:
         fail_on_error: yes
         strict: yes
-
-- name: Create/update templates in Kubernetes
-  k8s:
-    api_key: "{{ k8s_auth_api_key }}"
-    ca_cert: "{{ k8s_auth_ssl_ca_cert }}"
-    host: "{{ k8s_auth_host }}"
-    definition: "{{ lookup('template', item['name']) }}"
-    state: "{{ item['state'] }}"
-    # Ensure we see any failures in CI
-    wait: yes
-    validate:
-      fail_on_error: yes
-      strict: yes
-  with_items: "{{ k8s_templates }}"
 
 - when: k8s_rollout_after_deploy
   block:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -87,11 +87,11 @@
         strict: yes
 
   - name: Get deploy account name
-      k8s:
-        kind: ServiceAccount
-        namespace: "{{ k8s_namespace }}"
-        name: "deploy-account"
-      register: service_account
+    k8s:
+      kind: ServiceAccount
+      namespace: "{{ k8s_namespace }}"
+      name: "deploy-account"
+    register: service_account
 
   - set_fact:
       deploy_account_name: "{{ service_account.result.secrets.0.name }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -130,19 +130,15 @@
       fail_on_error: yes
       strict: yes
 
-- name: Create/update templates in Kubernetes
+- name: Create/Update secrets
   k8s:
-    api_key: "{{ k8s_auth_api_key }}"
-    ca_cert: "{{ k8s_auth_ssl_ca_cert }}"
+    definition: "{{ lookup('template', 'set_secrets.yaml.j2') }}"
+    state: present
     host: "{{ k8s_auth_host }}"
-    definition: "{{ lookup('template', item['name']) }}"
-    state: "{{ item['state'] }}"
-    # Ensure we see any failures in CI
     wait: yes
     validate:
       fail_on_error: yes
       strict: yes
-  with_items: "{{ k8s_templates }}"
 
 # Run migrations if wanted
 - when: k8s_migrations_enabled
@@ -207,6 +203,20 @@
       validate:
         fail_on_error: yes
         strict: yes
+
+- name: Create/update templates in Kubernetes
+  k8s:
+    api_key: "{{ k8s_auth_api_key }}"
+    ca_cert: "{{ k8s_auth_ssl_ca_cert }}"
+    host: "{{ k8s_auth_host }}"
+    definition: "{{ lookup('template', item['name']) }}"
+    state: "{{ item['state'] }}"
+    # Ensure we see any failures in CI
+    wait: yes
+    validate:
+      fail_on_error: yes
+      strict: yes
+  with_items: "{{ k8s_templates }}"
 
 - when: k8s_rollout_after_deploy
   block:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -85,10 +85,16 @@
       validate:
         fail_on_error: yes
         strict: yes
-    register: deploy_account
+
+  - name: Get deploy account name
+      k8s:
+        kind: ServiceAccount
+        namespace: "{{ k8s_namespace }}"
+        name: "deploy-account"
+      register: service_account
 
   - set_fact:
-      deploy_account_name: "{{ deploy_account.result.results.0.result.secrets.0.name }}"
+      deploy_account_name: "{{ service_account.result.secrets.0.name }}"
 
   - name: Get deploy account secret (contains secret token=k8s_auth_api_key)
     k8s_info:

--- a/templates/batchjob.yaml.j2
+++ b/templates/batchjob.yaml.j2
@@ -1,13 +1,3 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "{{ k8s_container_name }}-job-secrets"
-  labels:
-    app: "{{ k8s_container_name }}"
-  namespace: "{{ k8s_namespace }}"
-type: Opaque
-stringData: {{ k8s_environment_variables | to_json }}
----
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -26,7 +16,7 @@ spec:
           value: dns
         envFrom:
         - secretRef:
-            name: "{{ k8s_container_name }}-job-secrets"
+            name: "{{ k8s_container_name }}-secrets"
         ports:
         - containerPort: {{ k8s_container_port }}
         resources: {{ k8s_container_resources | to_json }}

--- a/templates/batchjob.yaml.j2
+++ b/templates/batchjob.yaml.j2
@@ -1,3 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ k8s_container_name }}-job-secrets"
+  labels:
+    app: "{{ k8s_container_name }}"
+  namespace: "{{ k8s_namespace }}"
+type: Opaque
+stringData: {{ k8s_environment_variables | to_json }}
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -16,7 +26,7 @@ spec:
           value: dns
         envFrom:
         - secretRef:
-            name: "{{ k8s_container_name }}-secrets"
+            name: "{{ k8s_container_name }}-job-secrets"
         ports:
         - containerPort: {{ k8s_container_port }}
         resources: {{ k8s_container_resources | to_json }}

--- a/templates/set_secrets.yaml.j2
+++ b/templates/set_secrets.yaml.j2
@@ -1,0 +1,16 @@
+{#
+Anywhere we need to inject a non-scalar value, we use to_json instead of to_yaml because it:
+1) more reliably includes wrapping {}
+2) behaves identically on Python 2 and Python 3
+(and all JSON is valid YAML).
+#}
+{% for container in k8s_web_containers %}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ container["name"] }}-secrets"
+  labels:
+    app: "{{ container["name"] }}"
+  namespace: "{{ k8s_namespace }}"
+type: Opaque
+stringData: {{ container["environment"] | to_json }}

--- a/templates/set_secrets.yaml.j2
+++ b/templates/set_secrets.yaml.j2
@@ -14,3 +14,4 @@ metadata:
   namespace: "{{ k8s_namespace }}"
 type: Opaque
 stringData: {{ container["environment"] | to_json }}
+{% endfor %}

--- a/templates/web.yaml.j2
+++ b/templates/web.yaml.j2
@@ -1,3 +1,9 @@
+{#
+Anywhere we need to inject a non-scalar value, we use to_json instead of to_yaml because it:
+1) more reliably includes wrapping {}
+2) behaves identically on Python 2 and Python 3
+(and all JSON is valid YAML).
+#}
 {% for container in k8s_web_containers %}
 apiVersion: apps/v1
 kind: Deployment

--- a/templates/web.yaml.j2
+++ b/templates/web.yaml.j2
@@ -1,19 +1,3 @@
-{#
-Anywhere we need to inject a non-scalar value, we use to_json instead of to_yaml because it:
-1) more reliably includes wrapping {}
-2) behaves identically on Python 2 and Python 3
-(and all JSON is valid YAML).
-#}
-{% for container in k8s_web_containers %}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "{{ container["name"] }}-secrets"
-  labels:
-    app: "{{ container["name"] }}"
-  namespace: "{{ k8s_namespace }}"
-type: Opaque
-stringData: {{ container["environment"] | to_json }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/templates/web.yaml.j2
+++ b/templates/web.yaml.j2
@@ -1,4 +1,4 @@
----
+{% for container in k8s_web_containers %}
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
The PR has, based on review, changed significantly. The role now uses an independent template to set secrets. This template creates secrets that are global.

Not reflected in the review comments is a discussion between Colin and myself based on Tobias' comment about a potential edge case:

1. Deployment is run and secrets are set
2. Secrets change
3. Deployment is run and migrations fail for some reason.

That leaves the pods in a state where they are not using the correct secrets, thus causing general chaos in the application.

I worked on a solution to create job secrets in the batch template, but the solution there caused the migrations to invariable fail without an obvious reason.

So, since the case we are worried about is pretty edge, I propose we continue with this solution until we can figure out the other.

The `secrets-in-jobs` is found here: https://github.com/caktus/ansible-role-django-k8s/pull/35

This PR fixes an issue that is described here: https://github.com/caktus/ansible-role-django-k8s/issues/12.