### PR TITLE
Move CI IAM user creation to django-k8s

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ caktus.django-k8s
 Changes
 -------
 
+v1.1.0 on Mar 4, 2021
+~~~~~~~~~~~~~~~~~~~~~~
+* Support adding a limited AWS IAM user for CI deploys
+
+
 v1.0.0 on Feb 17, 2021
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -194,16 +194,16 @@ registry), and possibly need to be able to read a secret from AWS Secrets Manage
 ``.vault_pass`` value). This playbook can create that user for you with the proper
 permissions. You can configure this with the following variables (defaults shown):
 
-```yaml
-k8s_ci_username: myproject-ci-user
-k8s_ci_repository_arn: "" # format: arn:aws:ecr:<REGION>:<ACCOUNT_NUMBER>:repository/<REPO_NAME>
-k8s_ci_vault_password_arn: "" # format: arn:aws:secretsmanager:<REGION>:<ACCOUNT_NUMBER>:secret:<NAME_OF_SECRET>
-```
+.. code-block:: yaml
+
+  k8s_ci_username: myproject-ci-user
+  k8s_ci_repository_arn: "" # format: arn:aws:ecr:<REGION>:<ACCOUNT_NUMBER>:repository/<REPO_NAME>
+  k8s_ci_vault_password_arn: "" # format: arn:aws:secretsmanager:<REGION>:<ACCOUNT_NUMBER>:secret:<NAME_OF_SECRET>
 
 Only ``k8s_ci_repository_arn`` is required. The REPO_NAME portion can be found
-[here](https://console.aws.amazon.com/ecr/repositories). The `k8s_ci_vault_password_arn`
+`here <https://console.aws.amazon.com/ecr/repositories>`_. The ``k8s_ci_vault_password_arn``
 is an optional pointer to a single secret in AWS Secrets Manager. The ARN can be found
-by going to this [link](https://console.aws.amazon.com/secretsmanager/home#/listSecrets)
+by going to this `link <https://console.aws.amazon.com/secretsmanager/home#/listSecrets>`_
 and then clicking on the secret you're sharing with the user. On some projects, we store
 the Ansible vault password in SecretsManager and then use an AWS CLI command to read the
 secret so other secrets in the repo can be decrypted. This allows the CI user to access
@@ -254,12 +254,12 @@ and then run ``ansible-playbook deploy-ci.yaml`` and it should work.
 
 After you run this role, the IAM user will be created with the proper permissions.
 You'll then need to use the AWS console to create an access key and secret key for that
-user. Take note of the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` values.
+user. Take note of the ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY`` values.
 
-Copy those 2 variables (and `AWS_DEFAULT_REGION`) into the CI environment variables
+Copy those 2 variables (and ``AWS_DEFAULT_REGION``) into the CI environment variables
 console.
 
-NOTE: Be aware that you'll need to make sure that `k8s_rollout_after_deploy` is disabled
+NOTE: Be aware that you'll need to make sure that ``k8s_rollout_after_deploy`` is disabled
 (which is the default), because the rollout commands use your local ``kubectl`` which
 likely has more permissions than the IAM service account that this role depends on. See
 https://github.com/caktus/ansible-role-django-k8s/issues/25.

--- a/README.rst
+++ b/README.rst
@@ -232,7 +232,13 @@ run on CI deploys. Create a playbook that looks like this:
 Normally we would just run this with ``ansible-playbook deploy-ci.yaml``, but
 unfortunately the Ansible IAM role still uses boto (instead of boto3) and boto is not
 compatible with using AWS profiles or AssumeRoles which we usually use to get access to
-AWS subaccounts. So first, you'll have to run this python script, which takes your
+AWS subaccounts. 
+
+If using `kubesae <https://github.com/caktus/invoke-kubesae>`_, make sure
+``c.config["aws"]["profile_name"]`` is configured in your tasks.py, and the
+following temporary credentials generation will occur automatically.
+
+Otherwise, you'll have to run this python script, which takes your
 profile (``saguaro-cluster`` in this example) and converts that into credentials that
 boto can use. Here is the python script:
 

--- a/README.rst
+++ b/README.rst
@@ -182,4 +182,84 @@ A separate playbook can be used to invoke this functionality:
           name: caktus.django-k8s
           tasks_from: aws_s3
 
-Run with: ``ansible-playbook deploy-s3.yml``.
+Run with: ``ansible-playbook deploy-s3.yaml``.
+
+
+Amazon IAM: Adding a limited AWS IAM user for CI deploys
+````````````````````````````````````````````````````````
+
+In order to be able to deploy to AWS from CI systems, you'll need to be able to
+authenticate as an IAM user that has the permissions to push to the AWS ECR (Docker
+registry), and possibly need to be able to read a secret from AWS Secrets Manager (the
+``.vault_pass`` value). This playbook can create that user for you with the proper
+permissions. You can configure this with the following variables (defaults shown):
+
+```yaml
+k8s_ci_username: myproject-ci-user
+k8s_ci_repository_arn: "" # format: arn:aws:ecr:<REGION>:<ACCOUNT_NUMBER>:repository/<REPO_NAME>
+k8s_ci_vault_password_arn: "" # format: arn:aws:secretsmanager:<REGION>:<ACCOUNT_NUMBER>:secret:<NAME_OF_SECRET>
+```
+
+Only ``k8s_ci_repository_arn`` is required. The REPO_NAME portion can be found
+[here](https://console.aws.amazon.com/ecr/repositories). The `k8s_ci_vault_password_arn`
+is an optional pointer to a single secret in AWS Secrets Manager. The ARN can be found
+by going to this [link](https://console.aws.amazon.com/secretsmanager/home#/listSecrets)
+and then clicking on the secret you're sharing with the user. On some projects, we store
+the Ansible vault password in SecretsManager and then use an AWS CLI command to read the
+secret so other secrets in the repo can be decrypted. This allows the CI user to access
+that command.
+
+You'll need to create a separate playbook to invoke this functionality because, once
+created, we don't need to try to recreate the user on each deploy AND because the CI
+user will not have the permissions to create itself, so we don't want this playbook to
+run on CI deploys. Create a playbook that looks like this:
+
+.. code-block:: yaml
+
+  ---
+  # file: deploy-ci.yaml
+
+  - hosts: k8s
+    vars:
+      ansible_connection: local
+      ansible_python_interpreter: "{{ ansible_playbook_python }}"
+    tasks:
+      - name: configure CI IAM user
+        import_role:
+          name: caktus.django-k8s
+          tasks_from: aws_ci
+
+Normally we would just run this with ``ansible-playbook deploy-ci.yaml``, but
+unfortunately the Ansible IAM role still uses boto (instead of boto3) and boto is not
+compatible with using AWS profiles or AssumeRoles which we usually use to get access to
+AWS subaccounts. So first, you'll have to run this python script, which takes your
+profile (``saguaro-cluster`` in this example) and converts that into credentials that
+boto can use. Here is the python script:
+
+.. code-block:: python
+
+   import boto3
+
+   session = boto3.Session(profile_name="saguaro-cluster")
+   credentials = session.get_credentials().get_frozen_credentials()
+
+   print(f'export AWS_ACCESS_KEY_ID="{credentials.access_key}"')
+   print(f'export AWS_SECRET_ACCESS_KEY="{credentials.secret_key}"')
+   print(f'export AWS_SECURITY_TOKEN="{credentials.token}"')
+   print(f'export AWS_SESSION_TOKEN="{credentials.token}"')
+
+
+The script will print statements to your console. Copy and paste those into your console
+and then run ``ansible-playbook deploy-ci.yaml`` and it should work.
+
+After you run this role, the IAM user will be created with the proper permissions.
+You'll then need to use the AWS console to create an access key and secret key for that
+user. Take note of the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` values.
+
+Copy those 2 variables (and `AWS_DEFAULT_REGION`) into the CI environment variables
+console.
+
+NOTE: Be aware that you'll need to make sure that `k8s_rollout_after_deploy` is disabled
+(which is the default), because the rollout commands use your local ``kubectl`` which
+likely has more permissions than the IAM service account that this role depends on. See
+https://github.com/caktus/ansible-role-django-k8s/issues/25.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -182,3 +182,10 @@ k8s_templates:
     state: "{{ k8s_worker_enabled | ternary('present', 'absent') }}"
   - name: workers_beat.yaml.j2
     state: "{{ (k8s_worker_enabled and k8s_worker_beat_enabled) | ternary('present', 'absent') }}"
+
+
+# Note that this is only supported on AWS clusters
+k8s_ci_create_user: "{{ k8s_ci_repository_arn | length > 0 }}"
+k8s_ci_username: ci-user
+k8s_ci_repository_arn: "" # format: arn:aws:ecr:<REGION>:<ACCOUNT_NUMBER>:repository/<REPO_NAME>
+k8s_ci_vault_password_arn: "" # format: arn:aws:secretsmanager:<REGION>:<ACCOUNT_NUMBER:secret:<SECRET_IDENTIFIER>

--- a/tasks/aws_ci.yml
+++ b/tasks/aws_ci.yml
@@ -1,0 +1,33 @@
+---
+
+#
+# Create an IAM user for CI to use when running deploys
+#
+
+- when: k8s_rollout_after_deploy and k8s_ci_create_user
+  fail:
+    msg: "Using a CI user when k8s_rollout_after_deploy will not work because this CI
+  user will not have the proper permissions to do a rollout (See README.rst note)"
+
+- name: Create CI user
+  iam:
+    name: "{{ k8s_ci_username }}"
+    state: present
+    iam_type: user
+  when: k8s_ci_create_user
+  register: ci_user
+
+- debug:
+    msg: |
+      IAM user {{ k8s_ci_username }} has been created.
+      Create an access_key in the AWS IAM console and store them in your CI's environment variables.
+  when: k8s_ci_create_user and ci_user is changed
+
+- name: Attach inline policy to user
+  iam_policy:
+    iam_type: user
+    iam_name: "{{ k8s_ci_username }}"
+    policy_name: "ECRPush"
+    state: present
+    policy_json: "{{ lookup( 'template', 'iam/ECRPush.json.j2') }}"
+  when: k8s_ci_create_user

--- a/templates/iam/ECRPush.json.j2
+++ b/templates/iam/ECRPush.json.j2
@@ -1,0 +1,49 @@
+{
+   "Version":"2012-10-17",
+   "Statement":[
+     {% if k8s_ci_vault_password_arn %}
+     {
+       {# https://docs.aws.amazon.com/cli/latest/reference/secretsmanager/get-secret-value.html#description #}
+       "Sid":"ReadSecretVaultPassword",
+       "Effect":"Allow",
+       "Action":[
+         "secretsmanager:GetSecretValue",
+         "kms:Decrypt"
+       ],
+       "Resource":"{{ k8s_ci_vault_password_arn }}"
+     },
+     {% endif %}
+     {
+       "Sid":"GetAuthorizationToken",
+       "Effect":"Allow",
+       "Action":[
+         "ecr:GetAuthorizationToken"
+       ],
+       "Resource":"*"
+     },
+     {
+       {# https://docs.aws.amazon.com/AmazonECR/latest/userguide/ecr_managed_policies.html#AmazonEC2ContainerRegistryPowerUser #}
+       "Sid":"ManageRepositoryContents",
+       "Effect":"Allow",
+       "Action":[
+         "ecr:GetAuthorizationToken",
+         "ecr:BatchCheckLayerAvailability",
+         "ecr:GetDownloadUrlForLayer",
+         "ecr:GetRepositoryPolicy",
+         "ecr:DescribeRepositories",
+         "ecr:ListImages",
+         "ecr:DescribeImages",
+         "ecr:BatchGetImage",
+         "ecr:GetLifecyclePolicy",
+         "ecr:GetLifecyclePolicyPreview",
+         "ecr:ListTagsForResource",
+         "ecr:DescribeImageScanFindings",
+         "ecr:InitiateLayerUpload",
+         "ecr:UploadLayerPart",
+         "ecr:CompleteLayerUpload",
+         "ecr:PutImage"
+       ],
+       "Resource":"{{ k8s_ci_repository_arn }}"
+     }
+   ]
+}


### PR DESCRIPTION
As I [mentioned in Slack](https://caktusgroup.slack.com/archives/CPY4B49ED/p1611880633066000) I believe the one-time CI user role creation belongs in django-k8s (like the S3 tasks that @copelco created). This moves that task here (and I'll put up the accompanying role for k8s-web-cluster shortly)