### PR TITLE
Update cluster-issuer annotation to new match cert-manager format

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,15 @@ caktus.django-k8s
 Changes
 -------
 
+v1.0.0 on TBD
+~~~~~~~~~~~~~~~~~~~~~~
+
+**BACKWARDS INCOMPATIBLE CHANGES:**
+
+* Use updated `cert-manager` annotation key: `cert-manager.io/cluster-issuer`
+* Must update to [caktus.k8s-web-cluster](https://github.com/caktus/ansible-role-k8s-web-cluster) v1.0.0
+
+
 v0.0.11 on Feb 2, 2021
 ~~~~~~~~~~~~~~~~~~~~~~
 * Adds ``no_log`` to rollout commands to prevent logging of environment vars.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ caktus.django-k8s
 Changes
 -------
 
-v1.0.0 on 2020-02-16
+v1.0.0 on Feb 17, 2021
 ~~~~~~~~~~~~~~~~~~~~~~
 
 **BACKWARDS INCOMPATIBLE CHANGES:**

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ caktus.django-k8s
 Changes
 -------
 
-v1.0.0 on TBD
+v1.0.0 on 2020-02-16
 ~~~~~~~~~~~~~~~~~~~~~~
 
 **BACKWARDS INCOMPATIBLE CHANGES:**

--- a/templates/web.yaml.j2
+++ b/templates/web.yaml.j2
@@ -79,7 +79,7 @@ metadata:
     kubernetes.io/ingress.class: nginx
     nginx.org/mergeable-ingress-type: master
 {% if k8s_ingress_certificate_issuer %}
-    certmanager.k8s.io/cluster-issuer: "{{ k8s_ingress_certificate_issuer }}"
+    cert-manager.io/cluster-issuer: "{{ k8s_ingress_certificate_issuer }}"
 {% endif %}
 spec:
   tls:


### PR DESCRIPTION
Relates to caktus/ansible-role-k8s-web-cluster#21 and its associated upcoming v1.0.0 release.