### PR TITLE
S3 role updates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@ caktus.django-k8s
 Changes
 -------
 
+v1.2.0 on TBD
+~~~~~~~~~~~~~~~~~~~~~~
+
+* Configure the [public access](https://docs.ansible.com/ansible/latest/collections/amazon/aws/s3_bucket_module.html#parameter-public_access) block on private S3 bucket using `s3_bucket` module
+  (requires Ansible 3.0+ or v1.3.0 of the amazon.aws collection)
+* 
+
+
 v1.1.0 on Mar 4, 2021
 ~~~~~~~~~~~~~~~~~~~~~~
 * Support adding a limited AWS IAM user for CI deploys

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,10 +7,10 @@ Changes
 v1.2.0 on TBD
 ~~~~~~~~~~~~~~~~~~~~~~
 
-* Configure the [public access](https://docs.ansible.com/ansible/latest/collections/amazon/aws/s3_bucket_module.html#parameter-public_access) block on private S3 bucket using `s3_bucket` module
+* Configure the `public access <https://docs.ansible.com/ansible/latest/collections/amazon/aws/s3_bucket_module.html#parameter-public_access>`_ block on private S3 bucket using `s3_bucket` module
   (requires Ansible 3.0+ or v1.3.0 of the amazon.aws collection)
 * Add `skip_duplicates: false` to *Attach inline policy to user* task to fix
-  deprecation warning and set it to the default value.
+  deprecation warning and `set it to the default value <https://docs.ansible.com/ansible/latest/collections/community/aws/iam_policy_module.html#parameter-skip_duplicates>`_.
 
 
 v1.1.0 on Mar 4, 2021

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,8 @@ v1.2.0 on TBD
 
 * Configure the [public access](https://docs.ansible.com/ansible/latest/collections/amazon/aws/s3_bucket_module.html#parameter-public_access) block on private S3 bucket using `s3_bucket` module
   (requires Ansible 3.0+ or v1.3.0 of the amazon.aws collection)
-* 
+* Add `skip_duplicates: false` to *Attach inline policy to user* task to fix
+  deprecation warning and set it to the default value.
 
 
 v1.1.0 on Mar 4, 2021

--- a/tasks/aws_s3.yml
+++ b/tasks/aws_s3.yml
@@ -22,18 +22,11 @@
     versioning: yes
     region: "{{ k8s_s3_region }}"
     encryption: AES256
-
-# Not available via Ansible module as of 7/2020
-- name: "block all public access to {{ k8s_s3_private_bucket }}"
-  command:
-    argv:
-      - aws
-      - s3api
-      - put-public-access-block
-      - --bucket
-      - "{{ k8s_s3_private_bucket }}"
-      - --public-access-block-configuration
-      - BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
+    public_access:
+      block_public_acls: true
+      ignore_public_acls: true
+      block_public_policy: false
+      restrict_public_buckets: false
 
 #
 # IAM OIDC identity provider and issuer

--- a/tasks/aws_s3.yml
+++ b/tasks/aws_s3.yml
@@ -81,6 +81,7 @@
     policy_name: "EKSBucketPolicy"
     state: present
     policy_json: "{{ lookup( 'template', 's3/AssetManagementPolicy.json.j2') }}"
+    skip_duplicates: false
 
 #
 # Service Account

--- a/tasks/aws_s3.yml
+++ b/tasks/aws_s3.yml
@@ -25,8 +25,8 @@
     public_access:
       block_public_acls: true
       ignore_public_acls: true
-      block_public_policy: false
-      restrict_public_buckets: false
+      block_public_policy: true
+      restrict_public_buckets: true
 
 #
 # IAM OIDC identity provider and issuer


### PR DESCRIPTION
* Configure the [public access](https://docs.ansible.com/ansible/latest/collections/amazon/aws/s3_bucket_module.html#parameter-public_access) block on private S3 bucket using `s3_bucket` module (requires Ansible 3.0+ or v1.3.0 of the amazon.aws collection)
* Add `skip_duplicates: false` to *Attach inline policy to user* task to fix deprecation warning and [set it to the default value](https://docs.ansible.com/ansible/latest/collections/community/aws/iam_policy_module.html#parameter-skip_duplicates).