### PR TITLE
Tag S3 buckets and fix deprecation warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,8 +9,11 @@ v1.2.0 on TBD
 
 * Configure the `public access <https://docs.ansible.com/ansible/latest/collections/amazon/aws/s3_bucket_module.html#parameter-public_access>`_ block on private S3 bucket using `s3_bucket` module
   (requires Ansible 3.0+ or v1.3.0 of the amazon.aws collection)
-* Add `skip_duplicates: false` to *Attach inline policy to user* task to fix
-  deprecation warning and `set it to the default value <https://docs.ansible.com/ansible/latest/collections/community/aws/iam_policy_module.html#parameter-skip_duplicates>`_.
+* Add `skip_duplicates: false` to fix
+  deprecation warnings and `set it to the default value
+  <https://docs.ansible.com/ansible/latest/collections/community/aws/iam_policy_module.html#parameter-skip_duplicates>`_ for the following tasks:
+  * aws_s3.yml's *Attach inline policy to user*
+  * aws_ci.yml's *Attach inline policy to user*
 
 
 v1.1.0 on Mar 4, 2021

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ v1.2.0 on TBD
   <https://docs.ansible.com/ansible/latest/collections/community/aws/iam_policy_module.html#parameter-skip_duplicates>`_ for the following tasks:
   * aws_s3.yml's *Attach inline policy to user*
   * aws_ci.yml's *Attach inline policy to user*
+* Support tagging S3 buckets
 
 
 v1.1.0 on Mar 4, 2021

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,8 +12,8 @@ v1.2.0 on TBD
 * Add `skip_duplicates: false` to fix
   deprecation warnings and `set it to the default value
   <https://docs.ansible.com/ansible/latest/collections/community/aws/iam_policy_module.html#parameter-skip_duplicates>`_ for the following tasks:
-  * aws_s3.yml's *Attach inline policy to user*
-  * aws_ci.yml's *Attach inline policy to user*
+    * aws_s3.yml's *Attach inline policy to user*
+    * aws_ci.yml's *Attach inline policy to user*
 * Support tagging S3 buckets
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -166,6 +166,8 @@ k8s_s3_iam_role: "S3ServiceAccountRole-{{ k8s_s3_namespace }}"
 k8s_s3_serviceaccount: "default"
 k8s_s3_public_bucket: "{{ k8s_s3_namespace }}-assets"
 k8s_s3_private_bucket: "{{ k8s_s3_namespace }}-private-assets"
+k8s_s3_tags: {}
+k8s_s3_tags_purge: yes
 
 k8s_templates:
   - name: registry_secret.yaml.j2

--- a/tasks/aws_ci.yml
+++ b/tasks/aws_ci.yml
@@ -30,4 +30,5 @@
     policy_name: "ECRPush"
     state: present
     policy_json: "{{ lookup( 'template', 'iam/ECRPush.json.j2') }}"
+    skip_duplicates: false
   when: k8s_ci_create_user

--- a/tasks/aws_s3.yml
+++ b/tasks/aws_s3.yml
@@ -10,6 +10,8 @@
     state: present
     versioning: yes
     region: "{{ k8s_s3_region }}"
+    tags: "{{ k8s_s3_tags }}"
+    purge_tags: "{{ k8s_s3_tags_purge }}"
 
 #
 # Private S3 assets bucket
@@ -21,6 +23,8 @@
     state: present
     versioning: yes
     region: "{{ k8s_s3_region }}"
+    tags: "{{ k8s_s3_tags }}"
+    purge_tags: "{{ k8s_s3_tags_purge }}"
     encryption: AES256
     public_access:
       block_public_acls: true


### PR DESCRIPTION
* Add `skip_duplicates: false` to *Attach inline policy to user* ``aws_s3.yml`` task to fix deprecation warning and [set it to the default value](https://docs.ansible.com/ansible/latest/collections/community/aws/iam_policy_module.html#parameter-skip_duplicates).
* Support tagging S3 buckets