### PR TITLE
Add support for deploying RabbitMQ cluster

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -141,6 +141,43 @@ Celery
   k8s_worker_resources: "{{ k8s_container_resources }}"
 
 
+RabbitMQ Support
+````````````````
+
+The RabbitMQ template included with this repo depends on the `RabbitMQ Cluster Operator for
+Kubernetes <https://www.rabbitmq.com/kubernetes/operator/operator-overview.html>`_. The
+operator is not installed with this role (since it's a cluster-wide resource). You
+can install it in your cluster by setting the ``k8s_rabbitmq_operator_version`` variable
+to the latest release (e.g., ``v1.9.0``) and including a playbook like this along side
+your other deployment scripts::
+
+  ---
+  # file: rabbitmq-operator.yaml
+
+  - hosts: k8s
+    vars:
+      ansible_python_interpreter: "{{ ansible_playbook_python }}"
+    tasks:
+    - name: Download cluster-operator manifest
+      ansible.builtin.get_url:
+        url: "https://github.com/rabbitmq/cluster-operator/releases/download/{{ k8s_rabbitmq_operator_version }}/cluster-operator.yml"
+        dest: /tmp/rabbitmq-cluster-operator.yml
+        mode: '0644'
+
+    - name: Apply cluster-operator manifest to the cluster
+      community.kubernetes.k8s:
+        state: present
+        src: /tmp/rabbitmq-cluster-operator.yml
+
+Once the operator is installed and running, you can create and customize a RabbitMQ cluster
+like so::
+
+  k8s_rabbitmq_enabled: true
+  k8s_rabbitmq_replicas: 3
+
+Please see ``defaults/main.yml`` for a complete list of the supported parameters.
+
+
 Amazon S3: IAM role for service accounts
 ````````````````````````````````````````
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,13 @@ k8s_domain_from_to_www_redirect: false
 
 k8s_namespace: "echoserver"
 
+# Optional: Set the storageClassName used for any PersistentVolumeClaims (PVCs) used in
+# templates in this role (including Redis, RabbitMQ, Elasticsearch, and Celery Beat).
+# Warning: Changing this value after resources are created is unsupported. Instead, you will need to
+# delete and recreate any pods that depend on it (assuming that is actually safe to do). You'll get a
+# "spec is immutable after creation" error if you do attempt to change it).
+# k8s_storage_class_name: ""
+
 k8s_memcached_enabled: false
 k8s_memcached_version: "1.6.9"
 
@@ -64,6 +71,23 @@ k8s_elasticsearch_node_replicas: 3
 k8s_elasticsearch_resources:
   requests:
     memory: "1Gi"
+
+# NOTE: Using RabbitMQ relies on the RabbitMQ Cluster Kubernetes Operator.
+# Follow the instructions in the README to install and configure it before
+# attempting to create a RabbitMQ cluster. The Operator also controls the
+# version of RabbitMQ that is installed (support for customizing spec.image
+# could be considered for the future, if needed).
+k8s_rabbitmq_enabled: false
+k8s_rabbitmq_cluster_name: rabbitmq
+# Using odd numbers is "highly recommended," and reducing this number ("cluster
+# scale down") is not supported.
+# See: https://www.rabbitmq.com/kubernetes/operator/using-operator.html#update
+k8s_rabbitmq_replicas: 1
+# Important: Updating the volume size after cluster creation does not appear
+# to be supported by the Operator (as of v1.9.0 at least). You'll need to
+# delete and recreate the cluster (by setting k8s_rabbitmq_enabled to false
+# temporarily) to effect a change in the volume size.
+k8s_rabbitmq_volume_size: "20Gi"
 
 k8s_environment_variables: {}
 
@@ -178,6 +202,8 @@ k8s_templates:
     state: "{{ k8s_elasticsearch_enabled | ternary('present', 'absent') }}"
   - name: memcached.yaml.j2
     state: "{{ k8s_memcached_enabled | ternary('present', 'absent') }}"
+  - name: rabbitmq.yaml.j2
+    state: "{{ k8s_rabbitmq_enabled | ternary('present', 'absent') }}"
   - name: web.yaml.j2
     state: present
   - name: workers.yaml.j2

--- a/templates/elasticsearch.yaml.j2
+++ b/templates/elasticsearch.yaml.j2
@@ -105,8 +105,10 @@ spec:
   - metadata:
       name: es-data
     spec:
+{% if k8s_storage_class_name is defined %}
+      storageClassName: "{{ k8s_storage_class_name }}"
+{% endif %}
       accessModes: ["ReadWriteOnce"]
       resources:
         requests:
           storage: {{ k8s_elasticsearch_volume_size }}
-

--- a/templates/rabbitmq.yaml.j2
+++ b/templates/rabbitmq.yaml.j2
@@ -1,0 +1,30 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: RabbitmqCluster
+metadata:
+  name: "{{ k8s_rabbitmq_cluster_name }}"
+  namespace: "{{ k8s_namespace }}"
+spec:
+  # Adapted from:
+  # https://github.com/rabbitmq/cluster-operator/blob/main/docs/examples/production-ready/rabbitmq.yaml
+  replicas: {{ k8s_rabbitmq_replicas }}
+  rabbitmq:
+    additionalConfig: |
+      cluster_partition_handling = pause_minority
+      vm_memory_high_watermark_paging_ratio = 0.99
+      disk_free_limit.relative = 1.0
+      collect_statistics_interval = 10000
+  persistence:
+{% if k8s_storage_class_name is defined %}
+    storageClassName: "{{ k8s_storage_class_name }}"
+{% endif %}
+    storage: "{{ k8s_rabbitmq_volume_size }}"
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - "{{ k8s_rabbitmq_cluster_name }}"
+        topologyKey: kubernetes.io/hostname

--- a/templates/redis.yaml.j2
+++ b/templates/redis.yaml.j2
@@ -4,6 +4,9 @@ metadata:
   name: redisvolume-claim
   namespace: "{{ k8s_namespace }}"
 spec:
+{% if k8s_storage_class_name is defined %}
+  storageClassName: "{{ k8s_storage_class_name }}"
+{% endif %}
   accessModes:
   - ReadWriteOnce
   resources:

--- a/templates/workers_beat.yaml.j2
+++ b/templates/workers_beat.yaml.j2
@@ -45,6 +45,9 @@ spec:
       name: beatvolume-claim
       namespace: "{{ k8s_namespace }}"
     spec:
+{% if k8s_storage_class_name is defined %}
+      storageClassName: "{{ k8s_storage_class_name }}"
+{% endif %}
       accessModes: ["ReadWriteOnce"]
       resources:
         requests:


### PR DESCRIPTION
Adds support for deploying a RabbitMQ cluster alongside the other auxiliary pods in an environment's namespace.

Notes:

- Depends on [RabbitMQ Operator](https://www.rabbitmq.com/kubernetes/operator/operator-overview.html) (must be deployed separately, as mentioned in the README).
- Also includes support for customizing the `storageClassName` used throughout the role.