### PR TITLE
Allow running multiple workers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -129,6 +129,7 @@ k8s_web_containers:
     htpasswd: "{{ k8s_container_htpasswd }}"
 
 k8s_worker_enabled: false
+k8s_worker_name: "celery-worker"
 k8s_worker_image: "{{ k8s_container_image }}"
 k8s_worker_image_pull_policy: "{{ k8s_container_image_pull_policy }}"
 k8s_worker_image_tag: "{{ k8s_container_image_tag }}"
@@ -150,6 +151,7 @@ k8s_worker_beat_command:
   - --pidfile=/data/beat.pid
   - --schedule=/data/schedulefile.db
 k8s_worker_container:
+  name: "{{ k8s_worker_name }}"
   image: "{{ k8s_worker_image }}"
   image_pull_policy: "{{ k8s_worker_image_pull_policy }}"
   tag: "{{ k8s_worker_image_tag }}"
@@ -159,6 +161,9 @@ k8s_worker_container:
   environment: "{{ k8s_environment_variables }}"
   worker_command: "{{ k8s_worker_command }}"
   beat_command: "{{ k8s_worker_beat_command }}"
+# Override k8s_worker_containers to add additional workers (background tasks):
+k8s_worker_containers:
+  - "{{ k8s_worker_container }}"
 
 k8s_worker_beat_enabled: false
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -236,6 +236,25 @@
       strict: yes
   with_items: "{{ k8s_templates }}"
 
+# FIXME: Remove in a future release
+- name: Clean up obsolete celery-secrets (replaced by celery-worker-secrets)
+  k8s:
+    api_key: "{{ k8s_auth_api_key }}"
+    ca_cert: "{{ k8s_auth_ssl_ca_cert }}"
+    host: "{{ k8s_auth_host }}"
+    definition: |
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "celery-secrets"
+        namespace: "{{ k8s_namespace }}"
+    state: absent
+    # Ensure we see any failures in CI
+    wait: yes
+    validate:
+      fail_on_error: yes
+      strict: yes
+
 # We use `no_log: True` to avoid logging env vars in CI
 - when: k8s_rollout_after_deploy
   block:

--- a/templates/workers.yaml.j2
+++ b/templates/workers.yaml.j2
@@ -4,30 +4,32 @@ Anywhere we need to inject a non-scalar value, we use to_json instead of to_yaml
 2) behaves identically on Python 2 and Python 3
 (and all JSON is valid YAML).
 #}
+{% for container in k8s_worker_containers %}
+{%+ if loop.index > 0 %}---{% endif +%}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "celery-secrets"
+  name: "{{ container["name"] }}-secrets"
   labels:
-    app: "celery"
+    app: "{{ container["name"] }}"
   namespace: "{{ k8s_namespace }}"
 type: Opaque
-stringData: {{ k8s_worker_container["environment"] | to_json }}
+stringData: {{ container["environment"] | to_json }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "celery-worker"
+  name: "{{ container["name"] }}"
   namespace: "{{ k8s_namespace }}"
 spec:
   selector:
     matchLabels:
-      app: "celery-worker"
-  replicas: {{ k8s_worker_container["replicas"] }}
+      app: "{{ container["name"] }}"
+  replicas: {{ container["replicas"] }}
   template:
     metadata:
       labels:
-        app: "celery-worker"
+        app: "{{ container["name"] }}"
     spec:
 {% if k8s_dockerconfigjson %}
       imagePullSecrets:
@@ -36,11 +38,11 @@ spec:
       imagePullSecrets: []
 {% endif %}
       containers:
-      - name: "celery-worker"
-        image: "{{ k8s_worker_container["image"] }}:{{ k8s_worker_container["tag"] }}"
-        imagePullPolicy: "{{ k8s_worker_container["image_pull_policy"] }}"
+      - name: "{{ container["name"] }}"
+        image: "{{ container["image"] }}:{{ container["tag"] }}"
+        imagePullPolicy: "{{ container["image_pull_policy"] }}"
         # command: do not override `command:` as we want to run the docker-entrypoint.sh before starting args
-        args: {{ k8s_worker_container["worker_command"] }}
+        args: {{ container["worker_command"] }}
         env:
         - name: GET_HOSTS_FROM
           value: dns
@@ -48,5 +50,6 @@ spec:
           value: "."
         envFrom:
         - secretRef:
-            name: "celery-secrets"
-        resources: {{ k8s_worker_container["resources"] | to_json }}
+            name: "{{ container["name"] }}-secrets"
+        resources: {{ container["resources"] | to_json }}
+{% endfor %}

--- a/templates/workers_beat.yaml.j2
+++ b/templates/workers_beat.yaml.j2
@@ -35,7 +35,7 @@ spec:
           value: .
         envFrom:
         - secretRef:
-            name: "celery-secrets"
+            name: "{{ k8s_worker_name }}-secrets"
         volumeMounts:
           - mountPath: /data
             name: beatvolume-claim


### PR DESCRIPTION
This PR adds a new variable `k8s_worker_containers` that can be extended to run multiple workers / background tasks, similar to the web containers.

It aims to be backwards-compatible and I believe that it mostly is, aside from needing to change the name of the celery `Secret` object from `celery-secrets` to `celery-worker-secrets`. The task attempts to clean out the old one, but it would probably be fine to leave it (aside from any confusion when debugging), if this step seems unnecessary.