### PR TITLE
Add `k8s_ingress_class`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -96,6 +96,7 @@ k8s_ingress_certificate_issuer: letsencrypt-production
 # TLS certificate as Subject Alternative Name(s)
 k8s_ingress_tls_domains_extra: []
 k8s_ingress_tls_domains: "{{ k8s_domain_names + k8s_ingress_tls_domains_extra }}"
+k8s_ingress_class: nginx
 
 k8s_container_name: web
 k8s_container_image: k8s.gcr.io/echoserver

--- a/templates/web.yaml.j2
+++ b/templates/web.yaml.j2
@@ -76,7 +76,7 @@ metadata:
   name: "ingress"
   namespace: "{{ k8s_namespace }}"
   annotations:
-    kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.class: "{{ k8s_ingress_class }}"
     nginx.org/mergeable-ingress-type: master
 {% if k8s_ingress_certificate_issuer %}
     cert-manager.io/cluster-issuer: "{{ k8s_ingress_certificate_issuer }}"
@@ -111,7 +111,7 @@ metadata:
   name: "ingress-{{ container["name"] }}"
   namespace: "{{ k8s_namespace }}"
   annotations:
-    kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.class: "{{ k8s_ingress_class }}"
     nginx.org/mergeable-ingress-type: minion
     nginx.ingress.kubernetes.io/backend-protocol: "{{ container["protocol"] }}"
 {% if container["htpasswd"] %}


### PR DESCRIPTION
Allow override of `kubernetes.io/ingress.class` annotation.

Related to:
- caktus/ansible-role-k8s-web-cluster#25
- ubuntu/microk8s#1890