### PR TITLE
Add `podAntiAffinity` to prefer scheduling app and worker pods on different nodes

### DIFF
--- a/templates/web.yaml.j2
+++ b/templates/web.yaml.j2
@@ -30,6 +30,18 @@ spec:
       labels:
         app: "{{ container["name"] }}"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - {{ container["name"] }}
+              topologyKey: kubernetes.io/hostname
 {% if k8s_dockerconfigjson %}
       imagePullSecrets:
       - name: registry-secret

--- a/templates/workers.yaml.j2
+++ b/templates/workers.yaml.j2
@@ -31,6 +31,18 @@ spec:
       labels:
         app: "{{ container["name"] }}"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - {{ container["name"] }}
+              topologyKey: kubernetes.io/hostname
 {% if k8s_dockerconfigjson %}
       imagePullSecrets:
       - name: registry-secret


### PR DESCRIPTION
I noticed when draining/rebooting nodes, sometimes the app pods are all scheduled on a single node, which then brings the site down until those pods are rescheduled. We can mitigate that by preferring to schedule app and worker pods on different nodes (when 2+ replicas and 2+ nodes are configured).

I looked briefly into allowing the policy to be customized, but it seems overly complex given it depends on the container names (which is now a list for both web and worker pods).