### PR TITLE
Allow overriding `Service` `spec.type` and `spec.loadBalancerIP` for services

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,10 +58,18 @@ k8s_namespace: "echoserver"
 
 k8s_memcached_enabled: false
 k8s_memcached_version: "1.6.9"
+k8s_memcached_service_type: ClusterIP
+# If service_type is LoadBalancer, you can optionally assign a fixed IP for your
+# load balancer (if suppported by the provider):
+# k8s_memcached_load_balancer_ip: w.x.y.z
 
 k8s_redis_enabled: false
 k8s_redis_version: "5.0.6"
 k8s_redis_volume_size: "20Gi"
+k8s_redis_service_type: ClusterIP
+# If service_type is LoadBalancer, you can optionally assign a fixed IP for your
+# load balancer (if suppported by the provider):
+# k8s_redis_load_balancer_ip: w.x.y.z
 
 k8s_elasticsearch_enabled: false
 k8s_elasticsearch_cluster_name: "app-elasticsearch-cluster"
@@ -88,6 +96,10 @@ k8s_rabbitmq_replicas: 1
 # delete and recreate the cluster (by setting k8s_rabbitmq_enabled to false
 # temporarily) to effect a change in the volume size.
 k8s_rabbitmq_volume_size: "20Gi"
+k8s_rabbitmq_service_type: ClusterIP
+# If service_type is LoadBalancer, you can optionally assign a fixed IP for your
+# load balancer (if suppported by the provider):
+# k8s_rabbitmq_load_balancer_ip: w.x.y.z
 
 k8s_environment_variables: {}
 

--- a/templates/memcached.yaml.j2
+++ b/templates/memcached.yaml.j2
@@ -31,6 +31,10 @@ metadata:
     app: "memcached"
   namespace: "{{ k8s_namespace }}"
 spec:
+  type: "{{ k8s_memcached_service_type }}"
+{% if "k8s_memcached_load_balancer_ip" is defined %}
+  loadBalancerIP: "{{ k8s_memcached_load_balancer_ip }}"
+{% endif %}
   ports:
   - protocol: TCP
     # Where other things in the cluster should try to connect to our application

--- a/templates/memcached.yaml.j2
+++ b/templates/memcached.yaml.j2
@@ -32,7 +32,7 @@ metadata:
   namespace: "{{ k8s_namespace }}"
 spec:
   type: "{{ k8s_memcached_service_type }}"
-{% if "k8s_memcached_load_balancer_ip" is defined %}
+{% if k8s_memcached_load_balancer_ip is defined %}
   loadBalancerIP: "{{ k8s_memcached_load_balancer_ip }}"
 {% endif %}
   ports:

--- a/templates/rabbitmq.yaml.j2
+++ b/templates/rabbitmq.yaml.j2
@@ -28,3 +28,10 @@ spec:
               values:
               - "{{ k8s_rabbitmq_cluster_name }}"
         topologyKey: kubernetes.io/hostname
+  override:
+    service:
+      spec:
+        type: "{{ k8s_rabbitmq_service_type }}"
+{% if "k8s_rabbitmq_load_balancer_ip" is defined %}
+        loadBalancerIP: "{{ k8s_rabbitmq_load_balancer_ip }}"
+{% endif %}

--- a/templates/rabbitmq.yaml.j2
+++ b/templates/rabbitmq.yaml.j2
@@ -32,6 +32,6 @@ spec:
     service:
       spec:
         type: "{{ k8s_rabbitmq_service_type }}"
-{% if "k8s_rabbitmq_load_balancer_ip" is defined %}
+{% if k8s_rabbitmq_load_balancer_ip is defined %}
         loadBalancerIP: "{{ k8s_rabbitmq_load_balancer_ip }}"
 {% endif %}

--- a/templates/redis.yaml.j2
+++ b/templates/redis.yaml.j2
@@ -54,7 +54,7 @@ metadata:
   namespace: "{{ k8s_namespace }}"
 spec:
   type: "{{ k8s_redis_service_type }}"
-{% if "k8s_redis_load_balancer_ip" is defined %}
+{% if k8s_redis_load_balancer_ip is defined %}
   loadBalancerIP: "{{ k8s_redis_load_balancer_ip }}"
 {% endif %}
   ports:

--- a/templates/redis.yaml.j2
+++ b/templates/redis.yaml.j2
@@ -53,6 +53,10 @@ metadata:
     app: "redis"
   namespace: "{{ k8s_namespace }}"
 spec:
+  type: "{{ k8s_redis_service_type }}"
+{% if "k8s_redis_load_balancer_ip" is defined %}
+  loadBalancerIP: "{{ k8s_redis_load_balancer_ip }}"
+{% endif %}
   ports:
   - protocol: TCP
     # Where other things in the cluster should try to connect to our application


### PR DESCRIPTION
This PR allows changing the service `spec.type` and `spec.loadBalancerIP` for Redis, Memcached, and RabbitMQ.

This can be useful if you need to expose these services to other assets outside of the cluster itself.