### PR TITLE
add support for customizing Deployment strategy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -96,6 +96,8 @@ k8s_container_image_tag: "1.10"
 k8s_container_port: 8080
 k8s_container_protocol: http
 k8s_container_replicas: 2
+k8s_container_strategy:
+  type: RollingUpdate
 k8s_container_resources:
   requests:
     memory: "256Mi"
@@ -121,6 +123,7 @@ k8s_web_containers:
     image_pull_policy: "{{ k8s_container_image_pull_policy }}"
     tag: "{{ k8s_container_image_tag }}"
     replicas: "{{ k8s_container_replicas }}"
+    strategy: "{{ k8s_container_strategy }}"
     resources: "{{ k8s_container_resources }}"
     port: "{{ k8s_container_port }}"
     protocol: "{{ k8s_container_protocol }}"
@@ -136,6 +139,8 @@ k8s_worker_image: "{{ k8s_container_image }}"
 k8s_worker_image_pull_policy: "{{ k8s_container_image_pull_policy }}"
 k8s_worker_image_tag: "{{ k8s_container_image_tag }}"
 k8s_worker_replicas: 2
+k8s_worker_strategy:
+  type: RollingUpdate
 k8s_worker_resources: "{{ k8s_container_resources }}"
 k8s_worker_celery_app: ""
 k8s_worker_command:
@@ -159,6 +164,7 @@ k8s_worker_container:
   image_pull_policy: "{{ k8s_worker_image_pull_policy }}"
   tag: "{{ k8s_worker_image_tag }}"
   replicas: "{{ k8s_worker_replicas }}"
+  strategy: "{{ k8s_worker_strategy }}"
   resources: "{{ k8s_worker_resources }}"
   celery_app: "{{ k8s_worker_celery_app }}"
   environment: "{{ k8s_environment_variables }}"

--- a/templates/web.yaml.j2
+++ b/templates/web.yaml.j2
@@ -37,6 +37,7 @@ spec:
     matchLabels:
       app: "{{ container["name"] }}"
   replicas: {{ container["replicas"] }}
+  strategy: {{ container["strategy"] | to_json }}
   template:
     metadata:
       labels:

--- a/templates/workers.yaml.j2
+++ b/templates/workers.yaml.j2
@@ -38,6 +38,7 @@ spec:
     matchLabels:
       app: "{{ container["name"] }}"
   replicas: {{ container["replicas"] }}
+  strategy: {{ container["strategy"] | to_json }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
You may need to delete or manually edit the Deployment when changing the strategy type (I guess K8s adds some extra markup to the manifest that is not deleted when the new version is merged):

```
failed: [test] (item={'name': 'workers.yaml.j2', 'state': 'present'}) => {"ansible_loop_var": "item", "changed": false, "error": 422, "item": {"name": "workers.yaml.j2", "state": "present"}, "msg": "Failed to patch object: b'{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"Deployment.apps \\\\\"bulksms\\\\\" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is \\'Recreate\\'\",\"reason\":\"Invalid\",\"details\":{\"name\":\"bulksms\",\"group\":\"apps\",\"kind\":\"Deployment\",\"causes\":[{\"reason\":\"FieldValueForbidden\",\"message\":\"Forbidden: may not be specified when strategy `type` is \\'Recreate\\'\",\"field\":\"spec.strategy.rollingUpdate\"}]},\"code\":422}\\n'", "reason": "Unprocessable Entity", "status": 422}
```