### PR TITLE
Add support for pgbouncer

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,6 +71,19 @@ k8s_redis_service_type: ClusterIP
 # load balancer (if suppported by the provider):
 # k8s_redis_load_balancer_ip: w.x.y.z
 
+k8s_pgbouncer_enabled: false
+k8s_pgbouncer_repo: "edoburu/pgbouncer"
+k8s_pgbouncer_version: "1.18.0"
+k8s_pgbouncer_service_type: ClusterIP
+# If service_type is LoadBalancer, you can optionally assign a fixed IP for your
+# load balancer (if suppported by the provider):
+# k8s_pgbouncer_load_balancer_ip: w.x.y.z
+# To use pgbouncer, you must define a k8s_pgbouncer_environment variable with
+# at minimum the DATABASE_URL and any other settings you wish to customize.
+# See: https://hub.docker.com/r/edoburu/pgbouncer/
+# k8s_pgbouncer_environment:
+#   DATABASE_URL: postgres://...
+
 k8s_elasticsearch_enabled: false
 k8s_elasticsearch_cluster_name: "app-elasticsearch-cluster"
 k8s_elasticsearch_version: "7.5.2"
@@ -233,6 +246,8 @@ k8s_templates:
     state: "{{ k8s_dockerconfigjson | ternary('present', 'absent') }}"
   - name: redis.yaml.j2
     state: "{{ k8s_redis_enabled | ternary('present', 'absent') }}"
+  - name: pgbouncer.yaml.j2
+    state: "{{ k8s_pgbouncer_enabled | ternary('present', 'absent') }}"
   - name: elasticsearch.yaml.j2
     state: "{{ k8s_elasticsearch_enabled | ternary('present', 'absent') }}"
   - name: memcached.yaml.j2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,6 +74,7 @@ k8s_redis_service_type: ClusterIP
 k8s_pgbouncer_enabled: false
 k8s_pgbouncer_repo: "edoburu/pgbouncer"
 k8s_pgbouncer_version: "1.18.0"
+k8s_pgbouncer_replicas: 1
 k8s_pgbouncer_service_type: ClusterIP
 # If service_type is LoadBalancer, you can optionally assign a fixed IP for your
 # load balancer (if suppported by the provider):

--- a/templates/pgbouncer.yaml.j2
+++ b/templates/pgbouncer.yaml.j2
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "pgbouncer-secrets"
+  labels:
+    app: "pgbouncer"
+  namespace: "{{ k8s_namespace }}"
+type: Opaque
+{% if k8s_pgbouncer_enabled %}
+{# fail loudly if k8s_pgbouncer_environment not defined when enabled (see defaults/main.yml) #}
+stringData: {{ k8s_pgbouncer_environment | to_json }}
+{% else %}
+stringData: {{ k8s_pgbouncer_environment | default({}) | to_json }}
+{% endif %}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "pgbouncer"
+  namespace: "{{ k8s_namespace }}"
+spec:
+  selector:
+    matchLabels:
+      app: "pgbouncer"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: "pgbouncer"
+    spec:
+      containers:
+      - name: "pgbouncer"
+        image: "{{ k8s_pgbouncer_repo }}:{{ k8s_pgbouncer_version }}"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: GET_HOSTS_FROM
+          value: dns
+        envFrom:
+        - secretRef:
+            name: "pgbouncer-secrets"
+        ports:
+        - containerPort: 5432
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "pgbouncer"
+  labels:
+    app: "pgbouncer"
+  namespace: "{{ k8s_namespace }}"
+spec:
+  type: "{{ k8s_pgbouncer_service_type }}"
+{% if k8s_pgbouncer_load_balancer_ip is defined %}
+  loadBalancerIP: "{{ k8s_pgbouncer_load_balancer_ip }}"
+{% endif %}
+  ports:
+  - protocol: TCP
+    # Where other things in the cluster should try to connect to our application
+    port: 5432
+    # Where our application is listening:
+    targetPort: 5432
+  selector:
+    app: "pgbouncer"

--- a/templates/pgbouncer.yaml.j2
+++ b/templates/pgbouncer.yaml.j2
@@ -22,12 +22,24 @@ spec:
   selector:
     matchLabels:
       app: "pgbouncer"
-  replicas: 1
+  replicas: {{ k8s_pgbouncer_replicas }}
   template:
     metadata:
       labels:
         app: "pgbouncer"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - pgbouncer
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: "pgbouncer"
         image: "{{ k8s_pgbouncer_repo }}:{{ k8s_pgbouncer_version }}"

--- a/templates/pgbouncer.yaml.j2
+++ b/templates/pgbouncer.yaml.j2
@@ -35,6 +35,8 @@ spec:
         env:
         - name: GET_HOSTS_FROM
           value: dns
+        - name: PGBOUNCER_SECRETS_HASH
+          value: "{{ k8s_pgbouncer_environment | default({}) | to_json | hash('sha256') }}"
         envFrom:
         - secretRef:
             name: "pgbouncer-secrets"


### PR DESCRIPTION
This PR adds support for pgbouncer to help reduce Postgres connection usage and latency.

```
appuser@app-77548bc9c6-gt96m:/code$ echo $DATABASE_URL
postgres://<snip>_staging:<snip>>@<snip>.us-east-2.rds.amazonaws.com:5432/<snip>_staging
appuser@app-77548bc9c6-gt96m:/code$ psql 'postgres://<snip>_staging:<snip>@pgbouncer:5432/<snip>_staging'
psql (11.18 (Debian 11.18-1.pgdg110+1), server 11.16)
Type "help" for help.

<snip>_staging=>  \d
                                        List of relations
 Schema |                        Name                         |   Type   |         Owner         
--------+-----------------------------------------------------+----------+-----------------------
 public | auth_group                                          | table    | <snip>_staging
 public | auth_group_id_seq                                   | sequence | <snip>_staging
 <snip>
```