### PR TITLE
Kubernetes 1.24 support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,17 @@ caktus.django-k8s
 Changes
 -------
 
+v1.6.0 on April 25th, 2023
+~~~~~~~~~~~~~~~~~~~~~
+
+* Manually create a non-expiring ``ServiceAccount`` token ``Secret`` to support Kubernetes v1.24. Relevant `release notes <https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#urgent-upgrade-notes>`_:
+
+    * The ``LegacyServiceAccountTokenNoAutoGeneration`` feature gate is beta, and enabled by default. When enabled, Secret API objects containing service account tokens are no longer auto-generated for every ``ServiceAccount``. Use the `TokenRequest <https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1>`_ API to acquire service account tokens, or if a non-expiring token is required, create a Secret API object for the token controller to populate with a service account token by following this `guide <https://kubernetes.io/docs/concepts/configuration/secret/#service-account-token-secrets>`_. 
+
+    * Each service account API key will be regenerated and will require you to rotate the ``k8s_auth_api_key`` Ansible variable(s).
+
+* Switch to ``kubernetes.core`` for Ansible 6.x+ support and use `fully qualified collection names (FQCNs) <https://github.com/ansible-collections/overview/blob/4e7fdd2512a4ec213b1beccef3b58dfb58b0d06e/README.rst#terminology>`_ to be explicit. The ``community.kubernetes`` collection was renamed to ``kubernetes.core`` in `v2.0.0 of the kubernetes.core collection <https://github.com/ansible-collections/community.kubernetes/blob/main/CHANGELOG.rst#v2-0-0>`_. Since `Ansible v3.0.0 <https://github.com/ansible-community/ansible-build-data/blob/main/3/CHANGELOG-v3.rst#included-collections>`_, both the ``kubernetes.core`` and ``community.kubernetes`` namespaced collections were included for convenience. `Ansible v6.0.0 <https://github.com/ansible-community/ansible-build-data/blob/f3602822e899015312852bb3e2debe52df109135/6/CHANGELOG-v6.rst#L4281>`_ removed the ``community.kubernetes`` convenience package.
+
 v1.5.2 on November 2nd, 2022
 ~~~~~~~~~~~~~~~~~~~~~
 * Add support for customizing Deployment strategy for web and worker processes

--- a/README.rst
+++ b/README.rst
@@ -257,7 +257,7 @@ And creating a playbook to deploy the cluster itself::
     tags: rabbitmq
     tasks:
     - name: Deploy RabbitMQ cluster
-      k8s:
+      kubernetes.core.k8s:
         context: "{{ k8s_context|mandatory }}"
         kubeconfig: "{{ k8s_kubeconfig }}"
         definition: "{{ lookup('template', item['name']) }}"

--- a/tasks/aws_s3.yml
+++ b/tasks/aws_s3.yml
@@ -93,7 +93,7 @@
 
 # https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html
 - name: "Associate IAM role with the service account in your cluster"
-  k8s:
+  kubernetes.core.k8s:
     state: present
     definition:
       apiVersion: v1

--- a/tasks/batchjob_tasks.yml
+++ b/tasks/batchjob_tasks.yml
@@ -1,5 +1,5 @@
 - name: remove any old "{{ batchjob.job_name }}" jobs
-  k8s:
+  kubernetes.core.k8s:
     api_key: "{{ k8s_auth_api_key }}"
     host: "{{ k8s_auth_host }}"
     ca_cert: "{{ k8s_auth_ssl_ca_cert }}"
@@ -11,7 +11,7 @@
       strict: yes
   when: batchjob.enabled | default(true)
 - name: run job "{{ batchjob.job_name }}"
-  k8s:
+  kubernetes.core.k8s:
     api_key: "{{ k8s_auth_api_key }}"
     host: "{{ k8s_auth_host }}"
     ca_cert: "{{ k8s_auth_ssl_ca_cert }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,7 +65,7 @@
 - when: not k8s_auth_api_key
   block:
   - name: Create/update namespace (needed for deploy account)
-    k8s:
+    kubernetes.core.k8s:
       definition: "{{ lookup('template', 'namespace.yaml.j2') }}"
       state: present
       host: "{{ k8s_auth_host }}"
@@ -76,7 +76,7 @@
         strict: yes
 
   - name: Create/update deploy account
-    k8s:
+    kubernetes.core.k8s:
       definition: "{{ lookup('template', 'deploy_account.yaml.j2') }}"
       state: present
       host: "{{ k8s_auth_host }}"
@@ -87,7 +87,7 @@
         strict: yes
 
   - name: Get deploy account secret (contains secret token=k8s_auth_api_key)
-    k8s_info:
+    kubernetes.core.k8s_info:
       kind: Secret
       namespace: "{{ k8s_namespace }}"
       name: "deploy-account-secret"
@@ -116,7 +116,7 @@
 # can only do this when we've been run with valid kubeconfig access.
 - when: kubeconfig_valid
   name: Update deploy account
-  k8s:
+  kubernetes.core.k8s:
     definition: "{{ lookup('template', 'deploy_account.yaml.j2') }}"
     state: present
     host: "{{ k8s_auth_host }}"
@@ -127,7 +127,7 @@
       strict: yes
 
 - name: Create/update job secret
-  k8s:
+  kubernetes.core.k8s:
     api_key: "{{ k8s_auth_api_key }}"
     host: "{{ k8s_auth_host }}"
     ca_cert: "{{ k8s_auth_ssl_ca_cert }}"
@@ -154,7 +154,7 @@
   include_tasks: batchjob_tasks.yml
 
 - name: Create/update templates in Kubernetes
-  k8s:
+  kubernetes.core.k8s:
     api_key: "{{ k8s_auth_api_key }}"
     ca_cert: "{{ k8s_auth_ssl_ca_cert }}"
     host: "{{ k8s_auth_host }}"
@@ -169,7 +169,7 @@
 
 # FIXME: Remove in a future release
 - name: Clean up obsolete celery-secrets (replaced by celery-worker-secrets)
-  k8s:
+  kubernetes.core.k8s:
     api_key: "{{ k8s_auth_api_key }}"
     ca_cert: "{{ k8s_auth_ssl_ca_cert }}"
     host: "{{ k8s_auth_host }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,22 +86,11 @@
         fail_on_error: yes
         strict: yes
 
-  - name: Get deploy account
-    k8s_info:
-      kind: ServiceAccount
-      host: "{{ k8s_auth_host }}"
-      namespace: "{{ k8s_namespace }}"
-      name: "deploy-account"
-    register: service_account
-
-  - set_fact:
-      deploy_account_name: "{{ service_account.resources.0.secrets.0.name }}"
-
   - name: Get deploy account secret (contains secret token=k8s_auth_api_key)
     k8s_info:
       kind: Secret
       namespace: "{{ k8s_namespace }}"
-      name: "{{ deploy_account_name }}"
+      name: "deploy-account-secret"
       host: "{{ k8s_auth_host }}"
     register: deploy_account_secret
 

--- a/templates/deploy_account.yaml.j2
+++ b/templates/deploy_account.yaml.j2
@@ -4,6 +4,15 @@ metadata:
   name: deploy-account
   namespace: "{{ k8s_namespace }}"
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: deploy-account-secret
+  namespace: "{{ k8s_namespace }}"
+  annotations:
+    kubernetes.io/service-account.name: deploy-account
+type: kubernetes.io/service-account-token
+---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
* Manually create a non-expiring `ServiceAccount` token `Secret` to support Kubernetes v1.24. Relevant [release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#urgent-upgrade-notes):

    > The `LegacyServiceAccountTokenNoAutoGeneration` feature gate is beta, and enabled by default. When enabled, Secret API objects containing service account tokens are no longer auto-generated for every `ServiceAccount`. Use the [TokenRequest](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/) API to acquire service account tokens, or if a non-expiring token is required, create a Secret API object for the token controller to populate with a service account token by following this [guide](https://kubernetes.io/docs/concepts/configuration/secret/#service-account-token-secrets). 

    **Each service account API key will be regenerated and will require you to rotate the `k8s_auth_api_key` Ansible variable(s).**

* Switch to `kubernetes.core` for Ansible 6.x+ support and use [fully qualified collection names (FQCNs)](https://github.com/ansible-collections/overview/blob/4e7fdd2512a4ec213b1beccef3b58dfb58b0d06e/README.rst#terminology) to be explicit. The `community.kubernetes` collection was renamed to `kubernetes.core` in [v2.0.0 of the kubernetes.core collection](https://github.com/ansible-collections/community.kubernetes/blob/main/CHANGELOG.rst#v2-0-0). Since [Ansible v3.0.0](https://github.com/ansible-community/ansible-build-data/blob/main/3/CHANGELOG-v3.rst#included-collections), both the `kubernetes.core` and `community.kubernetes` namespaced collections were included for convenience. [Ansible v6.0.0](https://github.com/ansible-community/ansible-build-data/blob/f3602822e899015312852bb3e2debe52df109135/6/CHANGELOG-v6.rst#L4281) removed the `community.kubernetes` convenience package.