### PR TITLE
Update default memcached, redis, and pgbouncer versions to recent ones

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ caktus.django-k8s
 Changes
 -------
 
+* Update default version memcached to 1.6.38, pgbouncer to 1.24.1, and redis to 7.4.3.
+
 v1.9.0 on February 26, 2024
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ caktus.django-k8s
 Changes
 -------
 
+v1.10.0 on May 19, 2025
+~~~~~~~~~~~~~~~~~~~~~~~
+
 * Update default version memcached to 1.6.38, pgbouncer to 1.24.1, and redis to 7.4.3.
 
 v1.9.0 on February 26, 2024

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,14 +70,14 @@ k8s_namespace: "echoserver"
 # k8s_storage_class_name: ""
 
 k8s_memcached_enabled: false
-k8s_memcached_version: "1.6.9"
+k8s_memcached_version: "1.6.38"
 k8s_memcached_service_type: ClusterIP
 # If service_type is LoadBalancer, you can optionally assign a fixed IP for your
 # load balancer (if suppported by the provider):
 # k8s_memcached_load_balancer_ip: w.x.y.z
 
 k8s_redis_enabled: false
-k8s_redis_version: "5.0.6"
+k8s_redis_version: "7.4.3"
 k8s_redis_volume_size: "20Gi"
 k8s_redis_service_type: ClusterIP
 # If service_type is LoadBalancer, you can optionally assign a fixed IP for your
@@ -86,7 +86,7 @@ k8s_redis_service_type: ClusterIP
 
 k8s_pgbouncer_enabled: false
 k8s_pgbouncer_repo: "edoburu/pgbouncer"
-k8s_pgbouncer_version: "1.18.0"
+k8s_pgbouncer_version: "1.24.1"
 k8s_pgbouncer_replicas: 1
 # Mount a Certificate from the k8s_namespace to pgBouncer's /etc/pgbouncer/ssl/
 # directory to enable TLS mode to use for connections from clients


### PR DESCRIPTION
Using old versions results in both

a) potential vulnerabilities in the server software itself
b) certain and copius vulnerabilities in the base image from the old version

Notes on these particular upgrades:

- memcached: 1.6.9 (2020-11-20) -> 1.6.38 (2025-03-19)

1.6.30 says "The builtin proxy has removed its old style lua API. There should be no active users of it, but if you use res = pool(r) or mcp.await syntax, please see the wiki documentation for updated API calls. This paves the way for many performance improvements."

I didn't see any server version compatibility notes with pymemcache (NOT the only Python interface).

- redis: 5.0.6 -> 7.4.3

redis 8 was released in the last couple of weeks and already has a recommended patch.  Additionally it has a new license to consider.

django-redis doesn't seem to care about the Redis version. redis-py says that our redis-py version 5.0.1 supports server "Version 5.0 to current".

- pgbouncer: 1.18.0 (2022-12-12) -> 1.24.1 (2025-04-16)

A "minor breaking change" is documented for pgbouncer 1.23.0:  "If you relied on the old behaviour of SIGTERM in your Dockerfile or Systemd service file you should now use SIGQUIT."