### PR TITLE
Fix PgBouncer Tag

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ caktus.django-k8s
 Changes
 -------
 
+v1.10.1 on May 19, 2025
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* Fix PgBouncer Docker tag
+
 v1.10.0 on May 19, 2025
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,7 +86,7 @@ k8s_redis_service_type: ClusterIP
 
 k8s_pgbouncer_enabled: false
 k8s_pgbouncer_repo: "edoburu/pgbouncer"
-k8s_pgbouncer_version: "1.24.1"
+k8s_pgbouncer_version: "v1.24.1-p0"
 k8s_pgbouncer_replicas: 1
 # Mount a Certificate from the k8s_namespace to pgBouncer's /etc/pgbouncer/ssl/
 # directory to enable TLS mode to use for connections from clients


### PR DESCRIPTION
We updated PgBouncer, Redis, and Memcached in #67. We did not notice that after version 19, the tag for PgBouncer needs to be pre-pended with `v` and have `-p0` appended. This PR fixes the tag.