### PR TITLE
Update memcached to latest version (1.6.39)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,10 @@ caktus.django-k8s
 
 Changes
 -------
+v1.10.2 on October 7, 2025
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* Update memcached default version to 1.6.39
 
 v1.10.1 on May 28, 2025
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,7 +70,7 @@ k8s_namespace: "echoserver"
 # k8s_storage_class_name: ""
 
 k8s_memcached_enabled: false
-k8s_memcached_version: "1.6.38"
+k8s_memcached_version: "1.6.39"
 k8s_memcached_service_type: ClusterIP
 # If service_type is LoadBalancer, you can optionally assign a fixed IP for your
 # load balancer (if suppported by the provider):


### PR DESCRIPTION
This PR updates the base `memcached` version to address security vulnerabilities.

**memcached: 1.6.38 (2025-03-19) -> 1.6.39 (2025-10-07)**

To see the all memcached version, go here: https://github.com/memcached/memcached/wiki/ReleaseNotes



