### PR TITLE
Update memcached and pgbouncer to latest, redis to latest 7.4.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@ caktus.django-k8s
 
 Changes
 -------
+v1.10.3 on January 9, 2026
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* Update memcached default version to 1.6.40, pgbouncer to v1.25.1-p0, and redis to 7.4.7.
+
 v1.10.2 on October 7, 2025
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,14 +70,14 @@ k8s_namespace: "echoserver"
 # k8s_storage_class_name: ""
 
 k8s_memcached_enabled: false
-k8s_memcached_version: "1.6.39"
+k8s_memcached_version: "1.6.40"
 k8s_memcached_service_type: ClusterIP
 # If service_type is LoadBalancer, you can optionally assign a fixed IP for your
 # load balancer (if suppported by the provider):
 # k8s_memcached_load_balancer_ip: w.x.y.z
 
 k8s_redis_enabled: false
-k8s_redis_version: "7.4.3"
+k8s_redis_version: "7.4.7"
 k8s_redis_volume_size: "20Gi"
 k8s_redis_service_type: ClusterIP
 # If service_type is LoadBalancer, you can optionally assign a fixed IP for your
@@ -86,7 +86,7 @@ k8s_redis_service_type: ClusterIP
 
 k8s_pgbouncer_enabled: false
 k8s_pgbouncer_repo: "edoburu/pgbouncer"
-k8s_pgbouncer_version: "v1.24.1-p0"
+k8s_pgbouncer_version: "v1.25.1-p0"
 k8s_pgbouncer_replicas: 1
 # Mount a Certificate from the k8s_namespace to pgBouncer's /etc/pgbouncer/ssl/
 # directory to enable TLS mode to use for connections from clients


### PR DESCRIPTION
A security tool used in some projects has identified vulnerabilities in the base images for these tools; updating to newer versions will resolve that.