### PR TITLE
Update memcached to latest, redis to latest 7.4.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,15 +3,24 @@ caktus.django-k8s
 
 Changes
 -------
-v1.11.1
-~~~~~~~
+v1.12.1
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Update memcached default version to 1.6.41, redis to 7.4.8.
 
-v1.11.0
-~~~~~~~
+v1.12.0 on April 15, 2026
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* trafik changes
+Add Traefik Ingress Support
+* Traefik Ingress Support: Added full support for Traefik Ingress objects and Custom Resource Definitions (CRDs).
+* Dual-Controller Logic: The role now allows side-by-side configuration or exclusive selection of Ingress-nginx and Traefik.
+* Dynamic ACME Routing: Automatic cert-manager solver switching. If k8s_traefik_ingress_is_default is set to true, TLS challenges are automatically routed through Traefik.
+* Middleware & CRD Management: Introduced k8s_traefik_ingress_resources to define and chain Traefik Middlewares and other CRDs dynamically.
+
+v1.11.0 on January 21, 2026
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Add support for ASGI web container
 
 v1.10.3 on January 9, 2026
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,16 @@ caktus.django-k8s
 
 Changes
 -------
+v1.11.1
+~~~~~~~
+
+* Update memcached default version to 1.6.41, redis to 7.4.8.
+
+v1.11.0
+~~~~~~~
+
+* trafik changes
+
 v1.10.3 on January 9, 2026
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,14 +70,14 @@ k8s_namespace: "echoserver"
 # k8s_storage_class_name: ""
 
 k8s_memcached_enabled: false
-k8s_memcached_version: "1.6.40"
+k8s_memcached_version: "1.6.41"
 k8s_memcached_service_type: ClusterIP
 # If service_type is LoadBalancer, you can optionally assign a fixed IP for your
 # load balancer (if suppported by the provider):
 # k8s_memcached_load_balancer_ip: w.x.y.z
 
 k8s_redis_enabled: false
-k8s_redis_version: "7.4.7"
+k8s_redis_version: "7.4.8"
 k8s_redis_volume_size: "20Gi"
 k8s_redis_service_type: ClusterIP
 # If service_type is LoadBalancer, you can optionally assign a fixed IP for your


### PR DESCRIPTION
A security tool used in some projects has identified vulnerabilities in the base images for these tools; updating to newer versions will resolve that.

XXX I see there's a 11.0.0 tag without changes documented.  What should be the entry for that?  I guess it isn't trafik-related???

XXX Also, should I branch off of 11.0.0 to make this change, to skip traefic for now?